### PR TITLE
fix(ci): add explicit workflow permissions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/jackby03/hardbox/security/code-scanning/3](https://github.com/jackby03/hardbox/security/code-scanning/3)

In general, the fix is to explicitly declare a permissions: block that grants only the minimal required access for the GITHUB_TOKEN. Since the jobs in this workflow only need to read the repository contents (for checkout) and upload artifacts (which does not require repository write permissions), contents: read is typically sufficient. Adding it at the top level of the workflow will apply to all jobs unless they define their own permissions block.

The best minimal fix without changing existing functionality is to add a root-level permissions: block with contents: read just under the 
ame: CI line. None of the jobs perform operations that need write access to contents, issues, or pull requests, nor do they interact with packages, so we do not need broader scopes. No additional methods, imports, or definitions are required; we only modify .github/workflows/ci.yaml to include this configuration.

Concretely:
- Edit .github/workflows/ci.yaml.
- Insert a new permissions: section after line 1 (
ame: CI) with:
  `yaml
  permissions:
    contents: read
  `
- Leave the rest of the workflow unchanged.

---

_Suggested fixes powered by Copilot Autofix. Review carefully before merging._