### PR TITLE
feat(modules): implement filesystem security module

### DIFF
--- a/internal/engine/registry.go
+++ b/internal/engine/registry.go
@@ -2,6 +2,7 @@ package engine
 
 import (
 	"github.com/hardbox-io/hardbox/internal/modules"
+	"github.com/hardbox-io/hardbox/internal/modules/filesystem"
 	"github.com/hardbox-io/hardbox/internal/modules/kernel"
 	"github.com/hardbox-io/hardbox/internal/modules/ntp"
 )
@@ -13,10 +14,10 @@ func registeredModules() []modules.Module {
 	// kernel and filesystem first, then services, then daemons, then access control.
 	return []modules.Module{
 		&kernel.Module{},
+		&filesystem.Module{},
 		&ntp.Module{},
 		// Stub placeholders — each will be fully implemented in its own package.
 		// &updates.Module{},
-		// &filesystem.Module{},
 		// &network.Module{},
 		// &services.Module{},
 		// &ssh.Module{},

--- a/internal/modules/filesystem/checks.go
+++ b/internal/modules/filesystem/checks.go
@@ -1,0 +1,241 @@
+package filesystem
+
+import (
+	"os"
+
+	"github.com/hardbox-io/hardbox/internal/modules"
+)
+
+// mountCheckSpec describes required mount options for a filesystem mountpoint.
+type mountCheckSpec struct {
+	check      modules.Check
+	mountPoint string
+	required   []string // options that must all be present
+}
+
+// filePermSpec describes required permissions and ownership for a file.
+type filePermSpec struct {
+	check    modules.Check
+	path     string      // absolute path on the target system
+	mode     os.FileMode // required permission bits
+	modeAlt  os.FileMode // alternative acceptable mode (0 = none)
+	wantUID  uint32      // expected owner UID
+	wantGID  uint32      // expected group GID
+	skipGID  bool        // skip GID check (e.g. shadow group varies by distro)
+	gidLabel string      // human-readable GID label for output
+}
+
+func mountChecks() []mountCheckSpec {
+	return []mountCheckSpec{
+		{
+			mountPoint: "/tmp",
+			required:   []string{"nodev", "nosuid", "noexec"},
+			check: modules.Check{
+				ID:          "fs-001",
+				Title:       "Mount /tmp with nodev,nosuid,noexec",
+				Description: "/tmp should be mounted with nodev, nosuid, and noexec to prevent execution of malicious files.",
+				Remediation: "Add nodev,nosuid,noexec to the /tmp entry in /etc/fstab and run: mount -o remount /tmp",
+				Severity:    modules.SeverityHigh,
+				Compliance: []modules.ComplianceRef{
+					{Framework: "CIS", Control: "1.1.2"},
+					{Framework: "NIST", Control: "CM-7"},
+				},
+			},
+		},
+		{
+			mountPoint: "/dev/shm",
+			required:   []string{"nodev", "nosuid", "noexec"},
+			check: modules.Check{
+				ID:          "fs-002",
+				Title:       "Mount /dev/shm with nodev,nosuid,noexec",
+				Description: "Shared memory should be mounted with nodev, nosuid, and noexec.",
+				Remediation: "Add nodev,nosuid,noexec to the /dev/shm entry in /etc/fstab and remount.",
+				Severity:    modules.SeverityHigh,
+				Compliance: []modules.ComplianceRef{
+					{Framework: "CIS", Control: "1.1.7"},
+					{Framework: "NIST", Control: "CM-7"},
+				},
+			},
+		},
+		{
+			mountPoint: "/home",
+			required:   []string{"nodev"},
+			check: modules.Check{
+				ID:          "fs-003",
+				Title:       "Mount /home with nodev",
+				Description: "Home directories should be mounted nodev to prevent device file creation.",
+				Remediation: "Add nodev to the /home entry in /etc/fstab and remount.",
+				Severity:    modules.SeverityMedium,
+				Compliance: []modules.ComplianceRef{
+					{Framework: "CIS", Control: "1.1.13"},
+					{Framework: "NIST", Control: "CM-7"},
+				},
+			},
+		},
+		{
+			mountPoint: "/var",
+			required:   []string{"nodev", "nosuid"},
+			check: modules.Check{
+				ID:          "fs-004",
+				Title:       "Mount /var with nodev,nosuid",
+				Description: "/var should be mounted with nodev and nosuid to limit attack surface.",
+				Remediation: "Add nodev,nosuid to the /var entry in /etc/fstab and remount.",
+				Severity:    modules.SeverityMedium,
+				Compliance: []modules.ComplianceRef{
+					{Framework: "CIS", Control: "1.1.14"},
+					{Framework: "NIST", Control: "CM-7"},
+				},
+			},
+		},
+		{
+			mountPoint: "/var/log",
+			required:   []string{"nodev", "nosuid", "noexec"},
+			check: modules.Check{
+				ID:          "fs-005",
+				Title:       "Mount /var/log with nodev,nosuid,noexec",
+				Description: "Log directory should not allow execution, device files, or setuid binaries.",
+				Remediation: "Add nodev,nosuid,noexec to the /var/log entry in /etc/fstab and remount.",
+				Severity:    modules.SeverityMedium,
+				Compliance: []modules.ComplianceRef{
+					{Framework: "CIS", Control: "1.1.15"},
+					{Framework: "NIST", Control: "AU-9"},
+				},
+			},
+		},
+		{
+			mountPoint: "/var/log/audit",
+			required:   []string{"nodev", "nosuid", "noexec"},
+			check: modules.Check{
+				ID:          "fs-006",
+				Title:       "Mount /var/log/audit with nodev,nosuid,noexec",
+				Description: "Audit log directory should not allow execution or special files.",
+				Remediation: "Add nodev,nosuid,noexec to the /var/log/audit entry in /etc/fstab and remount.",
+				Severity:    modules.SeverityMedium,
+				Compliance: []modules.ComplianceRef{
+					{Framework: "CIS", Control: "1.1.16"},
+					{Framework: "NIST", Control: "AU-9"},
+				},
+			},
+		},
+		{
+			mountPoint: "/boot",
+			required:   []string{"nodev", "nosuid"},
+			check: modules.Check{
+				ID:          "fs-007",
+				Title:       "Mount /boot with nodev,nosuid",
+				Description: "Boot partition should be mounted with restrictive options.",
+				Remediation: "Add nodev,nosuid to the /boot entry in /etc/fstab and remount.",
+				Severity:    modules.SeverityMedium,
+				Compliance: []modules.ComplianceRef{
+					{Framework: "CIS", Control: "1.1.17"},
+					{Framework: "NIST", Control: "CM-7"},
+				},
+			},
+		},
+	}
+}
+
+func filePermChecks() []filePermSpec {
+	return []filePermSpec{
+		{
+			path: "/etc/passwd", mode: 0o644,
+			wantUID: 0, wantGID: 0, gidLabel: "root",
+			check: modules.Check{
+				ID:          "fs-010",
+				Title:       "/etc/passwd permissions: 644 root:root",
+				Severity:    modules.SeverityHigh,
+				Remediation: "chmod 644 /etc/passwd && chown root:root /etc/passwd",
+				Compliance: []modules.ComplianceRef{
+					{Framework: "CIS", Control: "6.1.2"},
+					{Framework: "NIST", Control: "AC-6"},
+				},
+			},
+		},
+		{
+			path: "/etc/shadow", mode: 0o640, modeAlt: 0o000,
+			wantUID: 0, skipGID: true, gidLabel: "shadow/root",
+			check: modules.Check{
+				ID:          "fs-011",
+				Title:       "/etc/shadow permissions: 640 or 000 root:shadow",
+				Severity:    modules.SeverityCritical,
+				Remediation: "chmod 640 /etc/shadow && chown root:shadow /etc/shadow",
+				Compliance: []modules.ComplianceRef{
+					{Framework: "CIS", Control: "6.1.3"},
+					{Framework: "NIST", Control: "IA-5"},
+				},
+			},
+		},
+		{
+			path: "/etc/group", mode: 0o644,
+			wantUID: 0, wantGID: 0, gidLabel: "root",
+			check: modules.Check{
+				ID:          "fs-012",
+				Title:       "/etc/group permissions: 644 root:root",
+				Severity:    modules.SeverityMedium,
+				Remediation: "chmod 644 /etc/group && chown root:root /etc/group",
+				Compliance: []modules.ComplianceRef{
+					{Framework: "CIS", Control: "6.1.4"},
+					{Framework: "NIST", Control: "AC-6"},
+				},
+			},
+		},
+		{
+			path: "/etc/gshadow", mode: 0o640, modeAlt: 0o000,
+			wantUID: 0, skipGID: true, gidLabel: "shadow/root",
+			check: modules.Check{
+				ID:          "fs-013",
+				Title:       "/etc/gshadow permissions: 640 or 000 root:shadow",
+				Severity:    modules.SeverityCritical,
+				Remediation: "chmod 640 /etc/gshadow && chown root:shadow /etc/gshadow",
+				Compliance: []modules.ComplianceRef{
+					{Framework: "CIS", Control: "6.1.5"},
+					{Framework: "NIST", Control: "IA-5"},
+				},
+			},
+		},
+		{
+			path: "/etc/passwd-", mode: 0o644,
+			wantUID: 0, wantGID: 0, gidLabel: "root",
+			check: modules.Check{
+				ID:          "fs-014a",
+				Title:       "/etc/passwd- backup: 644 root:root",
+				Severity:    modules.SeverityMedium,
+				Remediation: "chmod 644 /etc/passwd- && chown root:root /etc/passwd-",
+				Compliance:  []modules.ComplianceRef{{Framework: "CIS", Control: "6.1.6"}},
+			},
+		},
+		{
+			path: "/etc/shadow-", mode: 0o640, modeAlt: 0o000,
+			wantUID: 0, skipGID: true, gidLabel: "shadow/root",
+			check: modules.Check{
+				ID:          "fs-014b",
+				Title:       "/etc/shadow- backup: 640 or 000",
+				Severity:    modules.SeverityCritical,
+				Remediation: "chmod 640 /etc/shadow- && chown root:shadow /etc/shadow-",
+				Compliance:  []modules.ComplianceRef{{Framework: "CIS", Control: "6.1.7"}},
+			},
+		},
+		{
+			path: "/etc/group-", mode: 0o644,
+			wantUID: 0, wantGID: 0, gidLabel: "root",
+			check: modules.Check{
+				ID:          "fs-014c",
+				Title:       "/etc/group- backup: 644 root:root",
+				Severity:    modules.SeverityMedium,
+				Remediation: "chmod 644 /etc/group- && chown root:root /etc/group-",
+				Compliance:  []modules.ComplianceRef{{Framework: "CIS", Control: "6.1.8"}},
+			},
+		},
+		{
+			path: "/etc/gshadow-", mode: 0o640, modeAlt: 0o000,
+			wantUID: 0, skipGID: true, gidLabel: "shadow/root",
+			check: modules.Check{
+				ID:          "fs-014d",
+				Title:       "/etc/gshadow- backup: 640 or 000",
+				Severity:    modules.SeverityCritical,
+				Remediation: "chmod 640 /etc/gshadow- && chown root:shadow /etc/gshadow-",
+				Compliance:  []modules.ComplianceRef{{Framework: "CIS", Control: "6.1.9"}},
+			},
+		},
+	}
+}

--- a/internal/modules/filesystem/export_test.go
+++ b/internal/modules/filesystem/export_test.go
@@ -1,0 +1,14 @@
+// export_test.go exposes internal constructor knobs for package-external tests.
+package filesystem
+
+// NewModuleForTest returns a Module with injected paths for unit testing.
+//   - mountsPath: path to a fake /proc/mounts file
+//   - fsRoot: root directory that replaces "/" for all file path lookups and scans
+//   - fstabPath: path to a fake /etc/fstab file
+func NewModuleForTest(mountsPath, fsRoot, fstabPath string) *Module {
+	return &Module{
+		mountsPath: mountsPath,
+		fsRoot:     fsRoot,
+		fstabPath:  fstabPath,
+	}
+}

--- a/internal/modules/filesystem/module.go
+++ b/internal/modules/filesystem/module.go
@@ -1,0 +1,731 @@
+// Package filesystem implements filesystem security hardening checks.
+// It covers mount options (fs-001..007), file permissions (fs-010..014),
+// world-writable files (fs-015), unowned files (fs-016), SUID/SGID
+// executables (fs-017), sticky bit on world-writable dirs (fs-018),
+// and sticky bit on /tmp (fs-019).
+package filesystem
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/hardbox-io/hardbox/internal/modules"
+	"github.com/hardbox-io/hardbox/internal/modules/util"
+)
+
+const (
+	defaultMountsPath = "/proc/mounts"
+	defaultFstabPath  = "/etc/fstab"
+)
+
+// Module implements filesystem security hardening.
+type Module struct {
+	mountsPath string // default: /proc/mounts; injectable for testing
+	fstabPath  string // default: /etc/fstab; injectable for testing
+	fsRoot     string // default: ""; prepended to all resolved paths for testing
+}
+
+func (m *Module) Name() string    { return "filesystem" }
+func (m *Module) Version() string { return "1.0" }
+
+func (m *Module) procMounts() string {
+	if m.mountsPath != "" {
+		return m.mountsPath
+	}
+	return defaultMountsPath
+}
+
+func (m *Module) fstab() string {
+	if m.fstabPath != "" {
+		return m.fstabPath
+	}
+	return defaultFstabPath
+}
+
+// resolvePath prepends fsRoot to abs when testing with a temp directory.
+func (m *Module) resolvePath(abs string) string {
+	if m.fsRoot != "" {
+		return filepath.Join(m.fsRoot, filepath.FromSlash(abs))
+	}
+	return abs
+}
+
+// scanRoot returns the base directory for filesystem scans.
+func (m *Module) scanRoot() string {
+	if m.fsRoot != "" {
+		return m.fsRoot
+	}
+	return "/"
+}
+
+// ── Audit ─────────────────────────────────────────────────────────────────────
+
+// Audit inspects mount options from /proc/mounts, file permissions, and
+// performs scans for world-writable files, unowned files, and SUID/SGID
+// executables. It is read-only and has no side effects.
+func (m *Module) Audit(_ context.Context, _ modules.ModuleConfig) ([]modules.Finding, error) {
+	var findings []modules.Finding
+
+	mountFindings, err := m.auditMounts()
+	if err != nil {
+		return nil, err
+	}
+	findings = append(findings, mountFindings...)
+	findings = append(findings, m.auditFilePerms()...)
+	findings = append(findings, m.auditStickyTmp()...)
+	findings = append(findings, m.auditWorldWritable()...)
+	findings = append(findings, m.auditSUIDSGID()...)
+	findings = append(findings, m.auditUnowned()...)
+
+	return findings, nil
+}
+
+// ── Mount option checks (fs-001..007) ─────────────────────────────────────────
+
+func (m *Module) auditMounts() ([]modules.Finding, error) {
+	content, err := os.ReadFile(m.procMounts())
+	if err != nil {
+		if os.IsNotExist(err) {
+			var findings []modules.Finding
+			for _, spec := range mountChecks() {
+				findings = append(findings, modules.Finding{
+					Check:  spec.check,
+					Status: modules.StatusSkipped,
+					Detail: "/proc/mounts not available",
+				})
+			}
+			return findings, nil
+		}
+		return nil, fmt.Errorf("filesystem: read %s: %w", m.procMounts(), err)
+	}
+
+	mounts := parseMounts(content)
+	var findings []modules.Finding
+
+	for _, spec := range mountChecks() {
+		opts, found := mounts[spec.mountPoint]
+		if !found {
+			findings = append(findings, modules.Finding{
+				Check:  spec.check,
+				Status: modules.StatusSkipped,
+				Detail: fmt.Sprintf("%s is not a separate mountpoint", spec.mountPoint),
+			})
+			continue
+		}
+
+		missing := missingOptions(opts, spec.required)
+		current := strings.Join(opts, ",")
+		target := strings.Join(spec.required, ",")
+
+		if len(missing) == 0 {
+			findings = append(findings, modules.Finding{
+				Check:   spec.check,
+				Status:  modules.StatusCompliant,
+				Current: current,
+				Target:  target,
+				Detail:  fmt.Sprintf("all required options present: %s", target),
+			})
+		} else {
+			findings = append(findings, modules.Finding{
+				Check:   spec.check,
+				Status:  modules.StatusNonCompliant,
+				Current: current,
+				Target:  target,
+				Detail:  fmt.Sprintf("missing options: %s", strings.Join(missing, ",")),
+			})
+		}
+	}
+
+	return findings, nil
+}
+
+// parseMounts returns mountpoint → options from /proc/mounts content.
+func parseMounts(data []byte) map[string][]string {
+	result := make(map[string][]string)
+	scanner := bufio.NewScanner(strings.NewReader(string(data)))
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		// Format: device mountpoint fstype options dump pass
+		fields := strings.Fields(line)
+		if len(fields) < 4 {
+			continue
+		}
+		result[fields[1]] = strings.Split(fields[3], ",")
+	}
+	return result
+}
+
+// missingOptions returns required options not present in present.
+func missingOptions(present, required []string) []string {
+	have := make(map[string]bool, len(present))
+	for _, o := range present {
+		have[strings.TrimSpace(o)] = true
+	}
+	var missing []string
+	for _, req := range required {
+		if !have[req] {
+			missing = append(missing, req)
+		}
+	}
+	return missing
+}
+
+// ── File permission checks (fs-010..014) ──────────────────────────────────────
+
+func (m *Module) auditFilePerms() []modules.Finding {
+	findings := make([]modules.Finding, 0, len(filePermChecks()))
+	for _, spec := range filePermChecks() {
+		findings = append(findings, m.checkFilePerm(spec))
+	}
+	return findings
+}
+
+func (m *Module) checkFilePerm(spec filePermSpec) modules.Finding {
+	path := m.resolvePath(spec.path)
+	info, err := os.Lstat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return modules.Finding{
+				Check:  spec.check,
+				Status: modules.StatusSkipped,
+				Detail: fmt.Sprintf("%s does not exist", spec.path),
+			}
+		}
+		return modules.Finding{
+			Check:  spec.check,
+			Status: modules.StatusError,
+			Detail: fmt.Sprintf("stat %s: %v", spec.path, err),
+		}
+	}
+
+	currentPerm := info.Mode().Perm()
+	modeOK := currentPerm == spec.mode || (spec.modeAlt != 0 && currentPerm == spec.modeAlt)
+
+	targetMode := fmt.Sprintf("%04o", spec.mode)
+	if spec.modeAlt != 0 {
+		targetMode += fmt.Sprintf("|%04o", spec.modeAlt)
+	}
+
+	uid, gid, haveOwner := statOwner(info)
+	ownerOK := true
+	var ownerIssue string
+	if haveOwner {
+		if uid != spec.wantUID {
+			ownerOK = false
+			ownerIssue += fmt.Sprintf("; uid %d != %d", uid, spec.wantUID)
+		}
+		if !spec.skipGID && gid != spec.wantGID {
+			ownerOK = false
+			ownerIssue += fmt.Sprintf("; gid %d != %d (%s)", gid, spec.wantGID, spec.gidLabel)
+		}
+	}
+
+	var currentStr, targetStr string
+	if haveOwner {
+		currentStr = fmt.Sprintf("%04o uid=%d gid=%d", currentPerm, uid, gid)
+	} else {
+		currentStr = fmt.Sprintf("%04o", currentPerm)
+	}
+	targetStr = fmt.Sprintf("%s uid=%d gid=%s", targetMode, spec.wantUID, spec.gidLabel)
+
+	if modeOK && ownerOK {
+		return modules.Finding{
+			Check:   spec.check,
+			Status:  modules.StatusCompliant,
+			Current: currentStr,
+			Target:  targetStr,
+			Detail:  "permissions and ownership are correct",
+		}
+	}
+
+	return modules.Finding{
+		Check:   spec.check,
+		Status:  modules.StatusNonCompliant,
+		Current: currentStr,
+		Target:  targetStr,
+		Detail:  fmt.Sprintf("mode: %04o (want %s)%s", currentPerm, targetMode, ownerIssue),
+	}
+}
+
+// ── Sticky bit on /tmp (fs-019) ───────────────────────────────────────────────
+
+var checkFS019 = modules.Check{
+	ID:          "fs-019",
+	Title:       "Sticky bit set on /tmp",
+	Severity:    modules.SeverityHigh,
+	Remediation: "Run: chmod +t /tmp",
+	Compliance: []modules.ComplianceRef{
+		{Framework: "CIS", Control: "1.1.1"},
+		{Framework: "NIST", Control: "CM-7"},
+	},
+}
+
+func (m *Module) auditStickyTmp() []modules.Finding {
+	tmpPath := m.resolvePath("/tmp")
+	info, err := os.Stat(tmpPath)
+	if err != nil {
+		status := modules.StatusError
+		if os.IsNotExist(err) {
+			status = modules.StatusSkipped
+		}
+		return []modules.Finding{{
+			Check:  checkFS019,
+			Status: status,
+			Detail: fmt.Sprintf("stat /tmp: %v", err),
+		}}
+	}
+
+	if info.Mode()&os.ModeSticky != 0 {
+		return []modules.Finding{{
+			Check:   checkFS019,
+			Status:  modules.StatusCompliant,
+			Current: "sticky bit set",
+			Target:  "sticky bit set",
+		}}
+	}
+
+	return []modules.Finding{{
+		Check:   checkFS019,
+		Status:  modules.StatusNonCompliant,
+		Current: "sticky bit not set",
+		Target:  "sticky bit set",
+		Detail:  "run: chmod +t /tmp",
+	}}
+}
+
+// ── World-writable files (fs-015) and sticky bit on dirs (fs-018) ─────────────
+
+var checkFS015 = modules.Check{
+	ID:          "fs-015",
+	Title:       "No world-writable files",
+	Severity:    modules.SeverityHigh,
+	Remediation: "Remove world-write permission: chmod o-w <file>",
+	Compliance: []modules.ComplianceRef{
+		{Framework: "CIS", Control: "6.1.12"},
+		{Framework: "NIST", Control: "AC-6"},
+	},
+}
+
+var checkFS018 = modules.Check{
+	ID:          "fs-018",
+	Title:       "Sticky bit set on all world-writable directories",
+	Severity:    modules.SeverityHigh,
+	Remediation: "Run: chmod +t <directory> for each listed directory.",
+	Compliance: []modules.ComplianceRef{
+		{Framework: "CIS", Control: "6.1.11"},
+		{Framework: "NIST", Control: "AC-6"},
+	},
+}
+
+func (m *Module) auditWorldWritable() []modules.Finding {
+	root := m.scanRoot()
+	var wwFiles []string
+	var wwDirsNoSticky []string
+
+	_ = filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return nil
+		}
+		// Skip virtual and noise-heavy directories.
+		rel, _ := filepath.Rel(root, path)
+		switch rel {
+		case "proc", "sys", "dev":
+			return fs.SkipDir
+		}
+
+		info, err := d.Info()
+		if err != nil {
+			return nil
+		}
+		mode := info.Mode()
+		if mode.Perm()&0o002 == 0 {
+			return nil
+		}
+		if mode.IsDir() {
+			if mode&os.ModeSticky == 0 {
+				wwDirsNoSticky = append(wwDirsNoSticky, path)
+			}
+		} else if mode.IsRegular() {
+			wwFiles = append(wwFiles, path)
+		}
+		return nil
+	})
+
+	const maxList = 20
+	var findings []modules.Finding
+
+	if len(wwFiles) == 0 {
+		findings = append(findings, modules.Finding{
+			Check:   checkFS015,
+			Status:  modules.StatusCompliant,
+			Current: "0 world-writable files",
+			Target:  "0 world-writable files",
+		})
+	} else {
+		findings = append(findings, modules.Finding{
+			Check:   checkFS015,
+			Status:  modules.StatusNonCompliant,
+			Current: fmt.Sprintf("%d world-writable file(s)", len(wwFiles)),
+			Target:  "0 world-writable files",
+			Detail:  strings.Join(wwFiles[:min(len(wwFiles), maxList)], "\n"),
+		})
+	}
+
+	if len(wwDirsNoSticky) == 0 {
+		findings = append(findings, modules.Finding{
+			Check:   checkFS018,
+			Status:  modules.StatusCompliant,
+			Current: "all world-writable directories have sticky bit",
+			Target:  "sticky bit on all world-writable directories",
+		})
+	} else {
+		findings = append(findings, modules.Finding{
+			Check:   checkFS018,
+			Status:  modules.StatusNonCompliant,
+			Current: fmt.Sprintf("%d world-writable dir(s) without sticky bit", len(wwDirsNoSticky)),
+			Target:  "sticky bit on all world-writable directories",
+			Detail:  strings.Join(wwDirsNoSticky[:min(len(wwDirsNoSticky), maxList)], "\n"),
+		})
+	}
+
+	return findings
+}
+
+// ── SUID/SGID scan (fs-017) ───────────────────────────────────────────────────
+
+var checkFS017 = modules.Check{
+	ID:          "fs-017",
+	Title:       "Audit SUID and SGID executables",
+	Severity:    modules.SeverityMedium,
+	Remediation: "Review listed SUID/SGID executables and remove the bit if not required: chmod u-s <file> or chmod g-s <file>",
+	Compliance: []modules.ComplianceRef{
+		{Framework: "CIS", Control: "6.1.14"},
+		{Framework: "NIST", Control: "CM-7"},
+	},
+}
+
+func (m *Module) auditSUIDSGID() []modules.Finding {
+	root := m.scanRoot()
+	var found []string
+
+	_ = filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return nil
+		}
+		rel, _ := filepath.Rel(root, path)
+		switch rel {
+		case "proc", "sys", "dev":
+			return fs.SkipDir
+		}
+		info, err := d.Info()
+		if err != nil {
+			return nil
+		}
+		mode := info.Mode()
+		if mode&os.ModeSetuid != 0 || mode&os.ModeSetgid != 0 {
+			found = append(found, path)
+		}
+		return nil
+	})
+
+	const maxList = 30
+	if len(found) == 0 {
+		return []modules.Finding{{
+			Check:   checkFS017,
+			Status:  modules.StatusManual,
+			Current: "0 SUID/SGID executables found",
+			Target:  "review all SUID/SGID executables",
+			Detail:  "no SUID/SGID executables detected in scan root",
+		}}
+	}
+	return []modules.Finding{{
+		Check:   checkFS017,
+		Status:  modules.StatusManual,
+		Current: fmt.Sprintf("%d SUID/SGID executable(s)", len(found)),
+		Target:  "review all SUID/SGID executables",
+		Detail:  strings.Join(found[:min(len(found), maxList)], "\n"),
+	}}
+}
+
+// ── Unowned/ungrouped files (fs-016) ─────────────────────────────────────────
+
+var checkFS016 = modules.Check{
+	ID:          "fs-016",
+	Title:       "No unowned or ungrouped files",
+	Severity:    modules.SeverityMedium,
+	Remediation: "Assign proper ownership: chown <user>:<group> <file>",
+	Compliance: []modules.ComplianceRef{
+		{Framework: "CIS", Control: "6.1.13"},
+		{Framework: "NIST", Control: "AC-6"},
+	},
+}
+
+func (m *Module) auditUnowned() []modules.Finding {
+	knownUIDs := parseIDsFromPasswd(m.resolvePath("/etc/passwd"))
+	knownGIDs := parseIDsFromGroup(m.resolvePath("/etc/group"))
+
+	if len(knownUIDs) == 0 && len(knownGIDs) == 0 {
+		return []modules.Finding{{
+			Check:  checkFS016,
+			Status: modules.StatusSkipped,
+			Detail: "could not read /etc/passwd and /etc/group",
+		}}
+	}
+
+	root := m.scanRoot()
+	var unowned []string
+
+	_ = filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return nil
+		}
+		rel, _ := filepath.Rel(root, path)
+		switch rel {
+		case "proc", "sys", "dev":
+			return fs.SkipDir
+		}
+		info, err := d.Info()
+		if err != nil {
+			return nil
+		}
+		uid, gid, haveOwner := statOwner(info)
+		if !haveOwner {
+			return nil
+		}
+		if !knownUIDs[uid] || !knownGIDs[gid] {
+			unowned = append(unowned, path)
+		}
+		return nil
+	})
+
+	const maxList = 20
+	if len(unowned) == 0 {
+		return []modules.Finding{{
+			Check:   checkFS016,
+			Status:  modules.StatusCompliant,
+			Current: "0 unowned/ungrouped files",
+			Target:  "0 unowned/ungrouped files",
+		}}
+	}
+	return []modules.Finding{{
+		Check:   checkFS016,
+		Status:  modules.StatusNonCompliant,
+		Current: fmt.Sprintf("%d unowned/ungrouped file(s)", len(unowned)),
+		Target:  "0 unowned/ungrouped files",
+		Detail:  strings.Join(unowned[:min(len(unowned), maxList)], "\n"),
+	}}
+}
+
+// parseIDsFromPasswd reads /etc/passwd and returns a set of known UIDs.
+func parseIDsFromPasswd(path string) map[uint32]bool {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return map[uint32]bool{}
+	}
+	ids := make(map[uint32]bool)
+	for _, line := range strings.Split(string(data), "\n") {
+		fields := strings.Split(line, ":")
+		if len(fields) < 3 {
+			continue
+		}
+		var uid uint32
+		if _, err := fmt.Sscanf(fields[2], "%d", &uid); err == nil {
+			ids[uid] = true
+		}
+	}
+	return ids
+}
+
+// parseIDsFromGroup reads /etc/group and returns a set of known GIDs.
+func parseIDsFromGroup(path string) map[uint32]bool {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return map[uint32]bool{}
+	}
+	ids := make(map[uint32]bool)
+	for _, line := range strings.Split(string(data), "\n") {
+		fields := strings.Split(line, ":")
+		if len(fields) < 3 {
+			continue
+		}
+		var gid uint32
+		if _, err := fmt.Sscanf(fields[2], "%d", &gid); err == nil {
+			ids[gid] = true
+		}
+	}
+	return ids
+}
+
+// ── Plan ─────────────────────────────────────────────────────────────────────
+
+// Plan returns reversible Changes to remediate non-compliant file permissions,
+// sticky bit on /tmp, and mount option entries in /etc/fstab.
+// Scan-based findings (fs-015..018) require manual review and are not auto-remediated.
+func (m *Module) Plan(ctx context.Context, _ modules.ModuleConfig) ([]modules.Change, error) {
+	findings, err := m.Audit(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	ncByID := make(map[string]modules.Finding)
+	for _, f := range findings {
+		if f.Status == modules.StatusNonCompliant {
+			ncByID[f.Check.ID] = f
+		}
+	}
+
+	var changes []modules.Change
+
+	// File permission changes (fs-010..014).
+	for _, spec := range filePermChecks() {
+		if _, nc := ncByID[spec.check.ID]; !nc {
+			continue
+		}
+		spec := spec
+		path := m.resolvePath(spec.path)
+		info, err := os.Lstat(path)
+		if err != nil {
+			continue
+		}
+		oldMode := info.Mode().Perm()
+		changes = append(changes, modules.Change{
+			Description:  fmt.Sprintf("filesystem: chmod %04o %s", spec.mode, spec.path),
+			DryRunOutput: fmt.Sprintf("  chmod %04o %s", spec.mode, spec.path),
+			Apply: func() error {
+				return os.Chmod(path, spec.mode)
+			},
+			Revert: func() error {
+				return os.Chmod(path, oldMode)
+			},
+		})
+	}
+
+	// Sticky bit on /tmp (fs-019).
+	if _, nc := ncByID["fs-019"]; nc {
+		tmpPath := m.resolvePath("/tmp")
+		info, err := os.Stat(tmpPath)
+		if err == nil {
+			oldMode := info.Mode()
+			changes = append(changes, modules.Change{
+				Description:  "filesystem: set sticky bit on /tmp",
+				DryRunOutput: fmt.Sprintf("  chmod +t /tmp  (current mode: %04o)", oldMode.Perm()),
+				Apply: func() error {
+					return os.Chmod(tmpPath, oldMode|os.ModeSticky)
+				},
+				Revert: func() error {
+					return os.Chmod(tmpPath, oldMode&^os.ModeSticky)
+				},
+			})
+		}
+	}
+
+	// Mount option changes via /etc/fstab.
+	mountChanges, err := m.planMounts(findings)
+	if err != nil {
+		return nil, err
+	}
+	changes = append(changes, mountChanges...)
+
+	return changes, nil
+}
+
+// planMounts builds a single atomic Change that updates /etc/fstab for all
+// non-compliant mount options, with a single Revert that restores the original file.
+func (m *Module) planMounts(findings []modules.Finding) ([]modules.Change, error) {
+	type mountFix struct {
+		mountPoint string
+		missing    []string
+	}
+	var fixes []mountFix
+
+	specByID := make(map[string]mountCheckSpec)
+	for _, spec := range mountChecks() {
+		specByID[spec.check.ID] = spec
+	}
+
+	for _, f := range findings {
+		if f.Status != modules.StatusNonCompliant {
+			continue
+		}
+		spec, ok := specByID[f.Check.ID]
+		if !ok {
+			continue
+		}
+		currentOpts := strings.Split(f.Current, ",")
+		missing := missingOptions(currentOpts, spec.required)
+		if len(missing) > 0 {
+			fixes = append(fixes, mountFix{mountPoint: spec.mountPoint, missing: missing})
+		}
+	}
+
+	if len(fixes) == 0 {
+		return nil, nil
+	}
+
+	fstabPath := m.fstab()
+	oldContent, readErr := os.ReadFile(fstabPath)
+	if readErr != nil && !os.IsNotExist(readErr) {
+		return nil, fmt.Errorf("filesystem: read %s: %w", fstabPath, readErr)
+	}
+	fileExisted := readErr == nil
+
+	var dryRun strings.Builder
+	newContent := string(oldContent)
+	for _, fix := range fixes {
+		fmt.Fprintf(&dryRun, "  %s: add mount options %s\n", fix.mountPoint, strings.Join(fix.missing, ","))
+		newContent = addFstabOptions(newContent, fix.mountPoint, fix.missing)
+	}
+
+	return []modules.Change{{
+		Description:  fmt.Sprintf("filesystem: update /etc/fstab mount options for %d mountpoint(s)", len(fixes)),
+		DryRunOutput: strings.TrimRight(dryRun.String(), "\n"),
+		Apply: func() error {
+			return util.AtomicWrite(fstabPath, []byte(newContent), 0o644)
+		},
+		Revert: func() error {
+			if !fileExisted {
+				return os.Remove(fstabPath)
+			}
+			return util.AtomicWrite(fstabPath, oldContent, 0o644)
+		},
+	}}, nil
+}
+
+// addFstabOptions appends missing mount options to the entry for mountpoint in
+// the fstab content. If the entry is absent, a new tmpfs line is appended.
+func addFstabOptions(content, mountpoint string, addOpts []string) string {
+	lines := strings.Split(content, "\n")
+	updated := false
+
+	for i, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+		fields := strings.Fields(trimmed)
+		if len(fields) < 4 || fields[1] != mountpoint {
+			continue
+		}
+		opts := strings.Split(fields[3], ",")
+		opts = append(opts, addOpts...)
+		fields[3] = strings.Join(opts, ",")
+		lines[i] = strings.Join(fields, "\t")
+		updated = true
+		break
+	}
+
+	if !updated {
+		lines = append(lines, fmt.Sprintf("tmpfs\t%s\ttmpfs\t%s\t0 0",
+			mountpoint, strings.Join(addOpts, ",")))
+	}
+
+	return strings.Join(lines, "\n")
+}

--- a/internal/modules/filesystem/module_test.go
+++ b/internal/modules/filesystem/module_test.go
@@ -1,0 +1,579 @@
+package filesystem_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/hardbox-io/hardbox/internal/modules"
+	"github.com/hardbox-io/hardbox/internal/modules/filesystem"
+)
+
+const (
+	mountsHardened = "testdata/proc_mounts_hardened"
+	mountsDefault  = "testdata/proc_mounts_default"
+)
+
+// ── interface compliance ──────────────────────────────────────────────────────
+
+func TestModule_ImplementsInterface(t *testing.T) {
+	var _ modules.Module = filesystem.NewModuleForTest("", "", "")
+}
+
+func TestModule_NameAndVersion(t *testing.T) {
+	m := filesystem.NewModuleForTest("", "", "")
+	if m.Name() != "filesystem" {
+		t.Errorf("Name(): got %q, want 'filesystem'", m.Name())
+	}
+	if m.Version() == "" {
+		t.Error("Version() should not be empty")
+	}
+}
+
+// ── Mount option auditing ─────────────────────────────────────────────────────
+
+func TestAudit_MountOptions_AllCompliant(t *testing.T) {
+	m := filesystem.NewModuleForTest(mountsHardened, t.TempDir(), "")
+	findings, err := m.Audit(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	mountIDs := map[string]bool{
+		"fs-001": true, "fs-002": true, "fs-003": true, "fs-004": true,
+		"fs-005": true, "fs-006": true, "fs-007": true,
+	}
+	for _, f := range findings {
+		if !mountIDs[f.Check.ID] {
+			continue
+		}
+		if f.Status != modules.StatusCompliant {
+			t.Errorf("check %s: expected compliant, got %s (detail: %s)",
+				f.Check.ID, f.Status, f.Detail)
+		}
+	}
+}
+
+func TestAudit_MountOptions_MissingOptions(t *testing.T) {
+	m := filesystem.NewModuleForTest(mountsDefault, t.TempDir(), "")
+	findings, err := m.Audit(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	nonCompliant := 0
+	for _, f := range findings {
+		if strings.HasPrefix(f.Check.ID, "fs-00") && f.Status == modules.StatusNonCompliant {
+			nonCompliant++
+		}
+	}
+	if nonCompliant < 7 {
+		t.Errorf("expected 7 non-compliant mount findings, got %d", nonCompliant)
+	}
+}
+
+func TestAudit_MountOptions_MissingDetail(t *testing.T) {
+	m := filesystem.NewModuleForTest(mountsDefault, t.TempDir(), "")
+	findings, err := m.Audit(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	for _, f := range findings {
+		if f.Check.ID == "fs-001" {
+			if f.Status != modules.StatusNonCompliant {
+				t.Fatalf("fs-001: expected non-compliant, got %s", f.Status)
+			}
+			if !strings.Contains(f.Detail, "noexec") {
+				t.Errorf("fs-001 detail should mention missing option 'noexec', got: %s", f.Detail)
+			}
+		}
+	}
+}
+
+func TestAudit_MountOptions_NotMounted_Skipped(t *testing.T) {
+	tmpDir := t.TempDir()
+	mountsPath := filepath.Join(tmpDir, "proc_mounts")
+	// Write a mounts file that only has /tmp — other entries are absent.
+	content := "tmpfs /tmp tmpfs rw,nosuid,nodev,noexec 0 0\n"
+	if err := os.WriteFile(mountsPath, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	m := filesystem.NewModuleForTest(mountsPath, tmpDir, "")
+	findings, err := m.Audit(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	for _, f := range findings {
+		if f.Check.ID == "fs-002" && f.Status != modules.StatusSkipped {
+			t.Errorf("fs-002 (/dev/shm absent): expected skipped, got %s", f.Status)
+		}
+	}
+}
+
+func TestAudit_MountOptions_NoMountsFile_Skipped(t *testing.T) {
+	m := filesystem.NewModuleForTest("/nonexistent/proc/mounts", t.TempDir(), "")
+	findings, err := m.Audit(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	for _, f := range findings {
+		if strings.HasPrefix(f.Check.ID, "fs-00") {
+			if f.Status != modules.StatusSkipped {
+				t.Errorf("check %s: expected skipped when /proc/mounts absent, got %s",
+					f.Check.ID, f.Status)
+			}
+		}
+	}
+}
+
+// ── File permission auditing ──────────────────────────────────────────────────
+
+func TestAudit_FilePerms_SkippedWhenMissing(t *testing.T) {
+	// fsRoot is an empty temp dir — all /etc/* files are absent.
+	m := filesystem.NewModuleForTest(mountsHardened, t.TempDir(), "")
+	findings, err := m.Audit(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	permIDs := map[string]bool{
+		"fs-010": true, "fs-011": true, "fs-012": true, "fs-013": true,
+	}
+	for _, f := range findings {
+		if permIDs[f.Check.ID] && f.Status != modules.StatusSkipped {
+			t.Errorf("check %s: expected skipped (file absent), got %s", f.Check.ID, f.Status)
+		}
+	}
+}
+
+func TestAudit_FilePerms_WrongMode(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix file permission model not available on Windows")
+	}
+
+	fsRoot := t.TempDir()
+	etcDir := filepath.Join(fsRoot, "etc")
+	if err := os.MkdirAll(etcDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Write /etc/passwd with 0777 (too permissive).
+	passwdPath := filepath.Join(etcDir, "passwd")
+	if err := os.WriteFile(passwdPath, []byte("root:x:0:0:root:/root:/bin/bash\n"), 0o777); err != nil {
+		t.Fatal(err)
+	}
+
+	m := filesystem.NewModuleForTest(mountsHardened, fsRoot, "")
+	findings, err := m.Audit(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	for _, f := range findings {
+		if f.Check.ID == "fs-010" {
+			if f.Status != modules.StatusNonCompliant {
+				t.Errorf("fs-010: expected non-compliant for 0777, got %s", f.Status)
+			}
+			return
+		}
+	}
+	t.Error("fs-010 finding not found")
+}
+
+func TestAudit_FilePerms_CorrectMode(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix file permission model not available on Windows")
+	}
+
+	fsRoot := t.TempDir()
+	etcDir := filepath.Join(fsRoot, "etc")
+	if err := os.MkdirAll(etcDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	passwdPath := filepath.Join(etcDir, "passwd")
+	if err := os.WriteFile(passwdPath, []byte("root:x:0:0:root:/root:/bin/bash\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	m := filesystem.NewModuleForTest(mountsHardened, fsRoot, "")
+	findings, err := m.Audit(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	for _, f := range findings {
+		if f.Check.ID == "fs-010" {
+			// Mode is correct; ownership check depends on platform — accept compliant or non-compliant.
+			if f.Status == modules.StatusError {
+				t.Errorf("fs-010: unexpected error status: %s", f.Detail)
+			}
+			return
+		}
+	}
+	t.Error("fs-010 finding not found")
+}
+
+// ── Sticky bit on /tmp (fs-019) ───────────────────────────────────────────────
+
+func TestAudit_StickyTmp_Compliant(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("sticky bit not supported on Windows")
+	}
+
+	fsRoot := t.TempDir()
+	tmpPath := filepath.Join(fsRoot, "tmp")
+	if err := os.MkdirAll(tmpPath, 0o777); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(tmpPath, os.ModeSticky|0o777); err != nil {
+		t.Fatal(err)
+	}
+
+	m := filesystem.NewModuleForTest(mountsHardened, fsRoot, "")
+	findings, err := m.Audit(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	for _, f := range findings {
+		if f.Check.ID == "fs-019" {
+			if f.Status != modules.StatusCompliant {
+				t.Errorf("fs-019: expected compliant, got %s", f.Status)
+			}
+			return
+		}
+	}
+	t.Error("fs-019 finding not found")
+}
+
+func TestAudit_StickyTmp_Missing(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("sticky bit not supported on Windows")
+	}
+
+	fsRoot := t.TempDir()
+	tmpPath := filepath.Join(fsRoot, "tmp")
+	if err := os.MkdirAll(tmpPath, 0o777); err != nil {
+		t.Fatal(err)
+	}
+	// Explicitly remove sticky bit.
+	if err := os.Chmod(tmpPath, 0o777); err != nil {
+		t.Fatal(err)
+	}
+
+	m := filesystem.NewModuleForTest(mountsHardened, fsRoot, "")
+	findings, err := m.Audit(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	for _, f := range findings {
+		if f.Check.ID == "fs-019" {
+			if f.Status != modules.StatusNonCompliant {
+				t.Errorf("fs-019: expected non-compliant without sticky bit, got %s", f.Status)
+			}
+			return
+		}
+	}
+	t.Error("fs-019 finding not found")
+}
+
+func TestAudit_StickyTmp_Skipped_WhenAbsent(t *testing.T) {
+	// fsRoot has no /tmp directory.
+	m := filesystem.NewModuleForTest(mountsHardened, t.TempDir(), "")
+	findings, err := m.Audit(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	for _, f := range findings {
+		if f.Check.ID == "fs-019" {
+			if f.Status != modules.StatusSkipped {
+				t.Errorf("fs-019: expected skipped when /tmp absent, got %s", f.Status)
+			}
+			return
+		}
+	}
+	t.Error("fs-019 finding not found")
+}
+
+// ── World-writable scan (fs-015) ─────────────────────────────────────────────
+
+func TestAudit_WorldWritable_Clean(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix permission model not available on Windows")
+	}
+
+	fsRoot := t.TempDir()
+	if err := os.WriteFile(filepath.Join(fsRoot, "normal.txt"), []byte("ok"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	m := filesystem.NewModuleForTest(mountsHardened, fsRoot, "")
+	findings, err := m.Audit(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	for _, f := range findings {
+		if f.Check.ID == "fs-015" {
+			if f.Status != modules.StatusCompliant {
+				t.Errorf("fs-015: expected compliant, got %s (detail: %s)", f.Status, f.Detail)
+			}
+			return
+		}
+	}
+	t.Error("fs-015 finding not found")
+}
+
+func TestAudit_WorldWritable_Found(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix permission model not available on Windows")
+	}
+
+	fsRoot := t.TempDir()
+	wwFile := filepath.Join(fsRoot, "world_writable.txt")
+	if err := os.WriteFile(wwFile, []byte("bad"), 0o666); err != nil {
+		t.Fatal(err)
+	}
+	// Explicitly set world-write bit.
+	if err := os.Chmod(wwFile, 0o666); err != nil {
+		t.Fatal(err)
+	}
+
+	m := filesystem.NewModuleForTest(mountsHardened, fsRoot, "")
+	findings, err := m.Audit(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	for _, f := range findings {
+		if f.Check.ID == "fs-015" {
+			if f.Status != modules.StatusNonCompliant {
+				t.Errorf("fs-015: expected non-compliant, got %s", f.Status)
+			}
+			if !strings.Contains(f.Detail, "world_writable.txt") {
+				t.Errorf("fs-015: detail should mention the world-writable file, got: %s", f.Detail)
+			}
+			return
+		}
+	}
+	t.Error("fs-015 finding not found")
+}
+
+// ── SUID/SGID scan (fs-017) ───────────────────────────────────────────────────
+
+func TestAudit_SUIDSGID_AlwaysManual(t *testing.T) {
+	m := filesystem.NewModuleForTest(mountsHardened, t.TempDir(), "")
+	findings, err := m.Audit(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	for _, f := range findings {
+		if f.Check.ID == "fs-017" {
+			if f.Status != modules.StatusManual {
+				t.Errorf("fs-017: expected manual (requires human review), got %s", f.Status)
+			}
+			return
+		}
+	}
+	t.Error("fs-017 finding not found")
+}
+
+// ── Check ID format ───────────────────────────────────────────────────────────
+
+func TestAudit_CheckIDs_HaveCorrectPrefix(t *testing.T) {
+	m := filesystem.NewModuleForTest(mountsHardened, t.TempDir(), "")
+	findings, err := m.Audit(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	for _, f := range findings {
+		if !strings.HasPrefix(f.Check.ID, "fs-") {
+			t.Errorf("check ID %q does not start with 'fs-'", f.Check.ID)
+		}
+		if f.Check.Title == "" {
+			t.Errorf("check %s has empty Title", f.Check.ID)
+		}
+		if f.Check.Severity == "" {
+			t.Errorf("check %s has empty Severity", f.Check.ID)
+		}
+	}
+}
+
+// ── Plan ─────────────────────────────────────────────────────────────────────
+
+func TestPlan_NoChanges_WhenCompliant(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("sticky bit not supported on Windows")
+	}
+
+	fsRoot := t.TempDir()
+	// Create /tmp with sticky bit set (fs-019 compliant).
+	tmpPath := filepath.Join(fsRoot, "tmp")
+	if err := os.MkdirAll(tmpPath, os.ModeSticky|0o777); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(tmpPath, os.ModeSticky|0o777); err != nil {
+		t.Fatal(err)
+	}
+
+	// No fstab file → all mount checks are skipped.
+	m := filesystem.NewModuleForTest(mountsHardened, fsRoot, filepath.Join(fsRoot, "fstab"))
+	changes, err := m.Plan(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// File permission checks are skipped (files absent), sticky bit compliant, mounts compliant.
+	if len(changes) != 0 {
+		t.Errorf("expected 0 changes, got %d", len(changes))
+	}
+}
+
+func TestPlan_ReturnsChanges_ForMissingMountOptions(t *testing.T) {
+	tmpDir := t.TempDir()
+	fstabPath := filepath.Join(tmpDir, "fstab")
+	if err := os.WriteFile(fstabPath, []byte("tmpfs /tmp tmpfs rw 0 0\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	m := filesystem.NewModuleForTest(mountsDefault, tmpDir, fstabPath)
+	changes, err := m.Plan(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(changes) == 0 {
+		t.Fatal("expected at least 1 change for non-compliant mount options, got 0")
+	}
+
+	// There should be exactly one batched fstab change.
+	hasFstabChange := false
+	for _, c := range changes {
+		if strings.Contains(c.Description, "fstab") {
+			hasFstabChange = true
+			if c.Description == "" {
+				t.Error("Change.Description should not be empty")
+			}
+			if c.DryRunOutput == "" {
+				t.Error("Change.DryRunOutput should not be empty")
+			}
+			if c.Apply == nil {
+				t.Error("Change.Apply should not be nil")
+			}
+			if c.Revert == nil {
+				t.Error("Change.Revert should not be nil")
+			}
+		}
+	}
+	if !hasFstabChange {
+		t.Error("expected a fstab change in plan")
+	}
+}
+
+func TestPlan_FstabChange_ApplyRevert(t *testing.T) {
+	tmpDir := t.TempDir()
+	fstabPath := filepath.Join(tmpDir, "fstab")
+	original := "tmpfs /tmp tmpfs rw 0 0\n"
+	if err := os.WriteFile(fstabPath, []byte(original), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	m := filesystem.NewModuleForTest(mountsDefault, tmpDir, fstabPath)
+	changes, err := m.Plan(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var fstabChange *modules.Change
+	for i := range changes {
+		if strings.Contains(changes[i].Description, "fstab") {
+			fstabChange = &changes[i]
+			break
+		}
+	}
+	if fstabChange == nil {
+		t.Fatal("fstab change not found in plan")
+	}
+
+	// Apply should update the file.
+	if err := fstabChange.Apply(); err != nil {
+		t.Fatalf("Apply() error: %v", err)
+	}
+	afterApply, _ := os.ReadFile(fstabPath)
+	if string(afterApply) == original {
+		t.Error("fstab content should have changed after Apply()")
+	}
+	// Applied content should contain some of the required options.
+	if !strings.Contains(string(afterApply), "noexec") && !strings.Contains(string(afterApply), "nosuid") {
+		t.Errorf("applied fstab should contain hardened options, got:\n%s", afterApply)
+	}
+
+	// Revert should restore the original.
+	if err := fstabChange.Revert(); err != nil {
+		t.Fatalf("Revert() error: %v", err)
+	}
+	afterRevert, _ := os.ReadFile(fstabPath)
+	if string(afterRevert) != original {
+		t.Errorf("Revert() should restore original fstab\nwant: %q\ngot:  %q", original, afterRevert)
+	}
+}
+
+func TestPlan_StickyBit_ApplyRevert(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("sticky bit not supported on Windows")
+	}
+
+	fsRoot := t.TempDir()
+	tmpPath := filepath.Join(fsRoot, "tmp")
+	if err := os.MkdirAll(tmpPath, 0o777); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(tmpPath, 0o777); err != nil {
+		t.Fatal(err)
+	}
+
+	m := filesystem.NewModuleForTest(mountsHardened, fsRoot, filepath.Join(fsRoot, "fstab"))
+	changes, err := m.Plan(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var stickyChange *modules.Change
+	for i := range changes {
+		if strings.Contains(changes[i].Description, "sticky") {
+			stickyChange = &changes[i]
+			break
+		}
+	}
+	if stickyChange == nil {
+		t.Fatal("sticky bit change not found in plan")
+	}
+
+	if err := stickyChange.Apply(); err != nil {
+		t.Fatalf("Apply() error: %v", err)
+	}
+	info, _ := os.Stat(tmpPath)
+	if info.Mode()&os.ModeSticky == 0 {
+		t.Error("sticky bit should be set after Apply()")
+	}
+
+	if err := stickyChange.Revert(); err != nil {
+		t.Fatalf("Revert() error: %v", err)
+	}
+	info, _ = os.Stat(tmpPath)
+	if info.Mode()&os.ModeSticky != 0 {
+		t.Error("sticky bit should be cleared after Revert()")
+	}
+}

--- a/internal/modules/filesystem/stat_other.go
+++ b/internal/modules/filesystem/stat_other.go
@@ -1,0 +1,10 @@
+//go:build !unix
+
+package filesystem
+
+import "os"
+
+// statOwner is a no-op stub on non-Unix systems.
+func statOwner(_ os.FileInfo) (uid, gid uint32, ok bool) {
+	return 0, 0, false
+}

--- a/internal/modules/filesystem/stat_unix.go
+++ b/internal/modules/filesystem/stat_unix.go
@@ -1,0 +1,17 @@
+//go:build unix
+
+package filesystem
+
+import (
+	"os"
+	"syscall"
+)
+
+// statOwner extracts the UID and GID from a FileInfo on Unix systems.
+func statOwner(info os.FileInfo) (uid, gid uint32, ok bool) {
+	st, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return 0, 0, false
+	}
+	return st.Uid, st.Gid, true
+}

--- a/internal/modules/filesystem/testdata/proc_mounts_default
+++ b/internal/modules/filesystem/testdata/proc_mounts_default
@@ -1,0 +1,9 @@
+sysfs /sys sysfs rw,relatime 0 0
+proc /proc proc rw,relatime 0 0
+tmpfs /tmp tmpfs rw,relatime 0 0
+tmpfs /dev/shm tmpfs rw,relatime 0 0
+/dev/sda1 /home ext4 rw,relatime 0 0
+/dev/sda2 /var ext4 rw,relatime 0 0
+/dev/sda3 /var/log ext4 rw,relatime 0 0
+/dev/sda4 /var/log/audit ext4 rw,relatime 0 0
+/dev/sda5 /boot ext4 rw,relatime 0 0

--- a/internal/modules/filesystem/testdata/proc_mounts_hardened
+++ b/internal/modules/filesystem/testdata/proc_mounts_hardened
@@ -1,0 +1,9 @@
+sysfs /sys sysfs rw,nosuid,nodev,noexec,relatime 0 0
+proc /proc proc rw,nosuid,nodev,noexec,relatime 0 0
+tmpfs /tmp tmpfs rw,nosuid,nodev,noexec 0 0
+tmpfs /dev/shm tmpfs rw,nosuid,nodev,noexec 0 0
+/dev/sda1 /home ext4 rw,nosuid,nodev,relatime 0 0
+/dev/sda2 /var ext4 rw,nosuid,nodev,relatime 0 0
+/dev/sda3 /var/log ext4 rw,nosuid,nodev,noexec,relatime 0 0
+/dev/sda4 /var/log/audit ext4 rw,nosuid,nodev,noexec,relatime 0 0
+/dev/sda5 /boot ext4 rw,nosuid,nodev,relatime 0 0


### PR DESCRIPTION
## Summary

- Implements the filesystem security module (issue #9) covering all 19 checks across mount options, file permissions, and filesystem scans
- Adds `Audit()` + `Plan()` with full `Revert()` support for all remediable findings
- Registered in `internal/engine/registry.go`

## Checks implemented

**Mount options** (reads `/proc/mounts`):
- `fs-001` /tmp — nodev,nosuid,noexec
- `fs-002` /dev/shm — nodev,nosuid,noexec
- `fs-003` /home — nodev
- `fs-004` /var — nodev,nosuid
- `fs-005` /var/log — nodev,nosuid,noexec
- `fs-006` /var/log/audit — nodev,nosuid,noexec
- `fs-007` /boot — nodev,nosuid

**File permissions** (uses `os.Lstat` + `syscall.Stat_t` on Unix):
- `fs-010..013` — `/etc/passwd`, `/etc/shadow`, `/etc/group`, `/etc/gshadow`
- `fs-014a..d` — backup files (`/etc/passwd-`, `/etc/shadow-`, etc.)

**Filesystem scans**:
- `fs-015` — world-writable files
- `fs-016` — unowned/ungrouped files (parses `/etc/passwd` + `/etc/group`)
- `fs-017` — SUID/SGID executables (`StatusManual` — requires human review)
- `fs-018` — sticky bit on world-writable directories
- `fs-019` — sticky bit on `/tmp`

## Plan / Revert

- File permission fixes: `os.Chmod` with old mode captured for revert
- Sticky bit on `/tmp`: `chmod +t` / `chmod -t`
- Mount options: single atomic `/etc/fstab` edit covering all non-compliant mounts, full revert to original content

## Test plan

- [x] `TestModule_ImplementsInterface` — interface compliance
- [x] `TestModule_NameAndVersion`
- [x] Mount audit: all compliant, missing options, absent mountpoint, missing `/proc/mounts`
- [x] File perms: skipped when absent, wrong mode, correct mode
- [x] Sticky bit: compliant, missing, absent `/tmp`
- [x] World-writable: clean scan, file detected
- [x] SUID/SGID: always `StatusManual`
- [x] Plan: no changes when compliant, fstab apply/revert, sticky bit apply/revert
- [x] `go test ./...` — all packages pass

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)