### PR TITLE
test(config): add tests for ModuleCfg method

### DIFF
--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,53 @@
+package config
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestConfig_ModuleCfg(t *testing.T) {
+	tests := []struct {
+		name       string
+		config     *Config
+		moduleName string
+		expected   ModuleConfig
+	}{
+		{
+			name: "Modules is nil",
+			config: &Config{
+				Modules: nil,
+			},
+			moduleName: "test-module",
+			expected:   ModuleConfig{},
+		},
+		{
+			name: "Module not found",
+			config: &Config{
+				Modules: map[string]ModuleConfig{
+					"other-module": {"key": "value"},
+				},
+			},
+			moduleName: "test-module",
+			expected:   ModuleConfig{},
+		},
+		{
+			name: "Module found",
+			config: &Config{
+				Modules: map[string]ModuleConfig{
+					"test-module": {"key": "value"},
+				},
+			},
+			moduleName: "test-module",
+			expected:   ModuleConfig{"key": "value"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.config.ModuleCfg(tt.moduleName)
+			if !reflect.DeepEqual(got, tt.expected) {
+				t.Errorf("ModuleCfg() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**What:** Added unit tests for the `ModuleCfg` method in `internal/config/config.go`.
**Coverage:** The tests cover scenarios when `Modules` is nil, when a module isn't found in the map, and when it is found.
**Result:** Increased test coverage and ensures regression prevention for simple configuration lookups.

---
*PR created automatically by Jules for task [6894352284873629785](https://jules.google.com/task/6894352284873629785) started by @jackby03*