### PR TITLE
feat(tui): wire module detail screen (screenModuleDetail)

### DIFF
--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -125,6 +125,16 @@ func (e *Engine) GetModules() []modules.Module {
 	return e.modules
 }
 
+// AuditModule runs the audit for the named module and returns its findings.
+func (e *Engine) AuditModule(ctx context.Context, name string) ([]modules.Finding, error) {
+	for _, m := range e.modules {
+		if m.Name() == name {
+			return m.Audit(ctx, modules.ModuleConfig(e.cfg.ModuleCfg(m.Name())))
+		}
+	}
+	return nil, fmt.Errorf("module %q not found", name)
+}
+
 // ListSnapshots prints available rollback snapshots.
 func (e *Engine) ListSnapshots(_ context.Context) error {
 	snaps, err := listSnapshots()

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -28,8 +28,9 @@ type App struct {
 	width  int
 	height int
 
-	dashboard dashboardModel
-	modules   modulesModel
+	dashboard    dashboardModel
+	modules      modulesModel
+	moduleDetail moduleDetailModel
 }
 
 // NewApp creates the root model, wiring in the config.
@@ -55,18 +56,20 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tea.WindowSizeMsg:
 		a.width = msg.Width
 		a.height = msg.Height
+		a.moduleDetail.height = msg.Height
 
 	case tea.KeyMsg:
-		// Global keybinds
-		switch msg.String() {
-		case "q", "ctrl+c":
+		// ctrl+c always quits regardless of screen
+		if msg.String() == "ctrl+c" {
 			return a, tea.Quit
 		}
 
-		// Screen-specific keybinds
+		// Screen-specific keybinds take precedence over global ones
 		switch a.screen {
 		case screenDashboard:
 			switch msg.String() {
+			case "q":
+				return a, tea.Quit
 			case "enter":
 				a.screen = screenModules
 				return a, nil
@@ -75,6 +78,20 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			switch msg.String() {
 			case "q", "esc":
 				a.screen = screenDashboard
+				return a, nil
+			case "enter":
+				mod := a.modules.modules[a.modules.selected]
+				a.moduleDetail = newModuleDetail(a.eng, mod, a.height)
+				a.screen = screenModuleDetail
+				return a, a.moduleDetail.Init()
+			}
+		case screenModuleDetail:
+			switch msg.String() {
+			case "q", "esc":
+				a.screen = screenModules
+				return a, nil
+			case "a":
+				a.screen = screenApplyConfirm
 				return a, nil
 			}
 		}
@@ -90,6 +107,10 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m, cmd := a.modules.Update(msg)
 		a.modules = m.(modulesModel)
 		return a, cmd
+	case screenModuleDetail:
+		m, cmd := a.moduleDetail.Update(msg)
+		a.moduleDetail = m.(moduleDetailModel)
+		return a, cmd
 	}
 
 	return a, nil
@@ -102,6 +123,8 @@ func (a App) View() string {
 		return a.dashboard.View()
 	case screenModules:
 		return a.modules.View()
+	case screenModuleDetail:
+		return a.moduleDetail.View()
 	default:
 		return lipgloss.NewStyle().Padding(1, 2).Render("Loading...")
 	}

--- a/internal/tui/moduledetail.go
+++ b/internal/tui/moduledetail.go
@@ -1,0 +1,210 @@
+package tui
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/hardbox-io/hardbox/internal/engine"
+	"github.com/hardbox-io/hardbox/internal/modules"
+)
+
+// auditResultMsg carries findings from an async audit command.
+type auditResultMsg struct {
+	findings []modules.Finding
+	err      error
+}
+
+// moduleDetailModel is the per-module audit detail screen.
+type moduleDetailModel struct {
+	eng      *engine.Engine
+	module   modules.Module
+	findings []modules.Finding
+	loading  bool
+	err      error
+	offset   int
+	height   int
+}
+
+func newModuleDetail(eng *engine.Engine, mod modules.Module, height int) moduleDetailModel {
+	return moduleDetailModel{
+		eng:     eng,
+		module:  mod,
+		loading: true,
+		height:  height,
+	}
+}
+
+func (m moduleDetailModel) Init() tea.Cmd {
+	name := m.module.Name()
+	return func() tea.Msg {
+		findings, err := m.eng.AuditModule(context.Background(), name)
+		return auditResultMsg{findings: findings, err: err}
+	}
+}
+
+func (m moduleDetailModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case auditResultMsg:
+		m.loading = false
+		m.err = msg.err
+		m.findings = msg.findings
+		m.offset = 0
+	case tea.KeyMsg:
+		visible := m.visibleRows()
+		maxOffset := len(m.findings) - visible
+		if maxOffset < 0 {
+			maxOffset = 0
+		}
+		switch msg.String() {
+		case "up", "k":
+			if m.offset > 0 {
+				m.offset--
+			}
+		case "down", "j":
+			if m.offset < maxOffset {
+				m.offset++
+			}
+		case "pgup":
+			m.offset -= visible
+			if m.offset < 0 {
+				m.offset = 0
+			}
+		case "pgdown":
+			m.offset += visible
+			if m.offset > maxOffset {
+				m.offset = maxOffset
+			}
+		}
+	}
+	return m, nil
+}
+
+func (m moduleDetailModel) View() string {
+	s := styles()
+	header := s.header.Render(fmt.Sprintf(" hardbox - %s  v%s ", m.module.Name(), m.module.Version()))
+
+	if m.loading {
+		return lipgloss.JoinVertical(lipgloss.Left,
+			header,
+			s.panel.Render("Auditing..."),
+		)
+	}
+
+	if m.err != nil {
+		return lipgloss.JoinVertical(lipgloss.Left,
+			header,
+			s.panel.Render(fmt.Sprintf("Error: %v", m.err)),
+		)
+	}
+
+	// Compliance score
+	compliant := 0
+	for _, f := range m.findings {
+		if f.IsCompliant() {
+			compliant++
+		}
+	}
+	total := len(m.findings)
+	score := 0
+	if total > 0 {
+		score = compliant * 100 / total
+	}
+	scoreBar := renderScoreBar(score, 30)
+	summary := lipgloss.JoinHorizontal(lipgloss.Top,
+		scoreBar,
+		fmt.Sprintf("  %d/%d compliant (%d%%)", compliant, total, score),
+	)
+
+	// Table header
+	tableHeader := lipgloss.NewStyle().
+		Foreground(lipgloss.Color("#94a3b8")).
+		Render(fmt.Sprintf("  %-12s %-34s %-14s %-14s %-14s %s",
+			"ID", "DESCRIPTION", "STATUS", "CURRENT", "TARGET", "SEV"))
+
+	// Visible rows with scroll
+	visible := m.visibleRows()
+	end := m.offset + visible
+	if end > total {
+		end = total
+	}
+
+	var rows []string
+	for _, f := range m.findings[m.offset:end] {
+		label, style := renderStatus(f.Status)
+		colored := style.Render(label)
+		pad := 14 - len(label)
+		if pad < 0 {
+			pad = 0
+		}
+		row := fmt.Sprintf("  %-12s %-34s %s%s%-14s %-14s %s",
+			f.Check.ID,
+			truncate(f.Check.Title, 34),
+			colored,
+			strings.Repeat(" ", pad),
+			truncate(f.Current, 14),
+			truncate(f.Target, 14),
+			string(f.Check.Severity),
+		)
+		rows = append(rows, row)
+	}
+
+	scrollNote := ""
+	if total > visible {
+		scrollNote = fmt.Sprintf("  [%d-%d of %d]", m.offset+1, end, total)
+	}
+
+	actions := s.actions.Render("[A] Apply   [↑/↓] Scroll   [PgUp/PgDn]   [Q/ESC] Back" + scrollNote)
+
+	body := lipgloss.JoinVertical(lipgloss.Left,
+		summary,
+		"",
+		tableHeader,
+		strings.Join(rows, "\n"),
+		"",
+		actions,
+	)
+
+	return lipgloss.JoinVertical(lipgloss.Left,
+		header,
+		s.panel.Render(body),
+	)
+}
+
+func (m moduleDetailModel) visibleRows() int {
+	rows := m.height - 12
+	if rows < 5 {
+		return 5
+	}
+	return rows
+}
+
+// renderStatus returns a display label and colour style for a finding status.
+func renderStatus(status modules.Status) (string, lipgloss.Style) {
+	switch status {
+	case modules.StatusCompliant:
+		return "compliant", lipgloss.NewStyle().Foreground(lipgloss.Color("#22c55e"))
+	case modules.StatusNonCompliant:
+		return "non-compliant", lipgloss.NewStyle().Foreground(lipgloss.Color("#ef4444"))
+	case modules.StatusManual:
+		return "manual", lipgloss.NewStyle().Foreground(lipgloss.Color("#f59e0b"))
+	case modules.StatusSkipped:
+		return "skipped", lipgloss.NewStyle().Foreground(lipgloss.Color("#64748b"))
+	case modules.StatusError:
+		return "error", lipgloss.NewStyle().Foreground(lipgloss.Color("#f97316"))
+	default:
+		return string(status), lipgloss.NewStyle()
+	}
+}
+
+// truncate shortens s to maxLen runes, adding "…" if cut.
+func truncate(s string, maxLen int) string {
+	runes := []rune(s)
+	if len(runes) <= maxLen {
+		return s
+	}
+	return string(runes[:maxLen-1]) + "…"
+}


### PR DESCRIPTION
## Summary

- Implements `screenModuleDetail` (Issue #4)
- Adds `Engine.AuditModule` method to run a single module's audit asynchronously via a Bubble Tea command
- New `moduleDetailModel` with:
  - Compliance score bar + `compliant/total (%)` summary
  - Scrollable check table: ID, description, colour-coded status badge, current value, target value, severity
  - Status colours: green = compliant, red = non-compliant, yellow = manual, grey = skipped, orange = error
  - Keyboard scroll: `↑/↓`, `j/k`, `PgUp/PgDn` with row count indicator when list is larger than terminal
- Navigation: `ENTER` on module list → detail; `q/ESC` on detail → module list; `a` → `screenApplyConfirm`
- Fixes key-ordering bug where `q` on non-root screens was quitting the app instead of navigating back

## Test plan

- [ ] `go build ./...` passes cleanly
- [ ] `go test ./...` — only pre-existing SSH file-permission failures on Windows (unrelated)
- [ ] Launch TUI, navigate Dashboard → Modules → select a module → ENTER → see audit results
- [ ] `q`/`ESC` returns to module list (not quit)
- [ ] `↑/↓` / `j/k` / `PgUp/PgDn` scrolls the check table
- [ ] `a` transitions to `screenApplyConfirm` placeholder

🤖 Generated with [Claude Code](https://claude.com/claude-code)