### PR TITLE
test(ci): validate audit smoke report

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -75,8 +75,27 @@ jobs:
 
       - name: Run audit (dry run, non-interactive)
         run: |
-          sudo ./hardbox audit --profile cis-level1 --format json --output audit-report.json || true
-          sudo chown $(id -u):$(id -g) audit-report.json
+          ./hardbox audit --profile cis-level1 --format json --output audit-report.json || true
+
+      - name: Validate audit report JSON structure
+        run: |
+          jq -e '
+            has("session_id") and
+            has("timestamp") and
+            has("profile") and
+            has("overall_score") and
+            (.modules | type == "array" and length > 0) and
+            all(.modules[]; has("name") and has("score") and has("findings") and (.findings | type == "array")) and
+            all(.modules[].findings[]?; has("check_id") and has("title") and has("status") and has("severity"))
+          ' audit-report.json > /dev/null
+
+      - name: Assert audit returned findings
+        run: |
+          jq -e '[.modules[].findings[]] | length > 0' audit-report.json > /dev/null
+
+      - name: Assert audit score is non-zero
+        run: |
+          jq -e '.overall_score > 0' audit-report.json > /dev/null
 
       - name: Upload audit report
         uses: actions/upload-artifact@v4

--- a/internal/modules/ssh/module_test.go
+++ b/internal/modules/ssh/module_test.go
@@ -354,6 +354,52 @@ func TestAudit_TableDriven(t *testing.T) {
 	}
 }
 
+func TestPlan_DryRunOutput_DoesNotModifyConfig(t *testing.T) {
+	path := writeTempConfig(t, "PermitRootLogin yes\n")
+	before, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile(before): %v", err)
+	}
+
+	m := ssh.NewModuleForTest(path)
+	changes, err := m.Plan(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("Plan(): unexpected error: %v", err)
+	}
+
+	if len(changes) == 0 {
+		t.Fatal("Plan(): expected at least one change")
+	}
+
+	var targetChange *modules.Change
+	for i := range changes {
+		if strings.Contains(changes[i].Description, "ssh-001") {
+			targetChange = &changes[i]
+			break
+		}
+	}
+	if targetChange == nil {
+		t.Fatal("Plan(): no change found for ssh-001")
+	}
+	if targetChange.DryRunOutput == "" {
+		t.Fatal("DryRunOutput should not be empty")
+	}
+	if !strings.Contains(targetChange.DryRunOutput, "Disable root login") {
+		t.Fatalf("DryRunOutput = %q, want title for ssh-001", targetChange.DryRunOutput)
+	}
+	if !strings.Contains(targetChange.DryRunOutput, "\"yes\" → \"no\"") {
+		t.Fatalf("DryRunOutput = %q, want current/target transition", targetChange.DryRunOutput)
+	}
+
+	after, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile(after): %v", err)
+	}
+	if string(after) != string(before) {
+		t.Fatalf("Plan() modified sshd_config during dry-run planning\nbefore:\n%s\nafter:\n%s", before, after)
+	}
+}
+
 // TestPlan_Apply_Revert exercises the full Plan→Apply→Revert cycle using a
 // temporary sshd_config, verifying that AtomicWrite integration works correctly.
 func TestPlan_Apply_Revert(t *testing.T) {


### PR DESCRIPTION
## What
Strengthen the CI self-audit smoke test by validating the generated JSON report and ensuring the run produces real findings.

## Why
Fixes #21

## How
- remove unnecessary sudo from the CI audit smoke step
- validate required top-level and finding fields with jq
- fail CI when the audit returns zero findings or an overall score of 0
- add an SSH dry-run planning test that proves Plan() emits dry-run output without mutating sshd_config

## Testing
- [x] go test ./internal/modules/ssh -run TestPlan_DryRunOutput_DoesNotModifyConfig
- [x] docker run --rm -v "${PWD}:/workspace" -w /workspace golang:1.22 bash -lc "/usr/local/go/bin/go test ./internal/modules/ssh"
- [ ] Full go test ./... -race

## Checklist
- [x] Branch branched from main
- [x] Conventional Commits format
- [ ] go vet ./... passes
- [ ] golangci-lint run passes
- [ ] Atomic write pattern for any file writes