### PR TITLE
feat(updates): implement automatic updates module

### DIFF
--- a/docs/COMPLIANCE.md
+++ b/docs/COMPLIANCE.md
@@ -77,6 +77,18 @@ This document is the authoritative cross-reference index.
 
 ---
 
+## Automatic Updates Module
+
+| Check ID | Title | CIS | NIST | STIG | PCI | HIPAA | ISO |
+|---|---|---|---|---|---|---|---|
+| upd-001 | Package manager GPG keys configured | 1.2.1 | SI-2 | — | 6.3.3 | — | A.12.6.1 |
+| upd-002 | Security updates repository enabled | 1.2.2 | SI-2 | — | 6.3.3 | — | A.12.6.1 |
+| upd-003 | Unattended security upgrades configured | 1.9 | SI-2 | — | 6.3.3 | — | A.12.6.1 |
+| upd-004 | Auto-reboot after kernel updates (configurable) | — | SI-2 | — | — | — | — |
+| upd-005 | apt-get update via local mirror (optional) | — | — | — | — | — | — |
+
+---
+
 ## Users & PAM Module
 
 | Check ID | Title | CIS | NIST | STIG | PCI | HIPAA | ISO |

--- a/internal/engine/registry.go
+++ b/internal/engine/registry.go
@@ -6,6 +6,7 @@ import (
 	"github.com/hardbox-io/hardbox/internal/modules/kernel"
 	"github.com/hardbox-io/hardbox/internal/modules/ntp"
 	"github.com/hardbox-io/hardbox/internal/modules/services"
+	"github.com/hardbox-io/hardbox/internal/modules/updates"
 )
 
 // registeredModules returns the list of all built-in hardening modules.
@@ -18,8 +19,8 @@ func registeredModules() []modules.Module {
 		&filesystem.Module{},
 		&ntp.Module{},
 		&services.Module{},
+		&updates.Module{},
 		// Stub placeholders — each will be fully implemented in its own package.
-		// &updates.Module{},
 		// &network.Module{},
 		// &ssh.Module{},
 		// &firewall.Module{},

--- a/internal/modules/updates/export_test.go
+++ b/internal/modules/updates/export_test.go
@@ -1,0 +1,29 @@
+package updates
+
+// TestOptions configures file paths and family override for tests.
+type TestOptions struct {
+	Family             string
+	APTSourcesList     string
+	APTSourcesListDir  string
+	APTAutoUpgrades    string
+	APTUnattended      string
+	APTTrustedGPG      string
+	APTTrustedGPGDir   string
+	USRShareKeyrings   string
+	DNFAutomaticConfig string
+}
+
+// NewModuleForTest creates a Module with test-specific paths.
+func NewModuleForTest(o TestOptions) *Module {
+	return &Module{
+		familyOverride:         o.Family,
+		aptSourcesListPath:     o.APTSourcesList,
+		aptSourcesListDir:      o.APTSourcesListDir,
+		aptAutoUpgradesPath:    o.APTAutoUpgrades,
+		aptUnattendedPath:      o.APTUnattended,
+		aptTrustedGPGPath:      o.APTTrustedGPG,
+		aptTrustedGPGDir:       o.APTTrustedGPGDir,
+		usrShareKeyringsDir:    o.USRShareKeyrings,
+		dnfAutomaticConfigPath: o.DNFAutomaticConfig,
+	}
+}

--- a/internal/modules/updates/module.go
+++ b/internal/modules/updates/module.go
@@ -1,0 +1,582 @@
+package updates
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"net"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/hardbox-io/hardbox/internal/modules"
+)
+
+const (
+	defaultAPTSourceList       = "/etc/apt/sources.list"
+	defaultAPTSourcesListDir   = "/etc/apt/sources.list.d"
+	defaultAPTAutoUpgradesPath = "/etc/apt/apt.conf.d/20auto-upgrades"
+	defaultAPTUnattendedPath   = "/etc/apt/apt.conf.d/50unattended-upgrades"
+	defaultAPTTrustedGPG       = "/etc/apt/trusted.gpg"
+	defaultAPTTrustedGPGDir    = "/etc/apt/trusted.gpg.d"
+	defaultUSRShareKeyringsDir = "/usr/share/keyrings"
+	defaultDNFAutomaticConf    = "/etc/dnf/automatic.conf"
+)
+
+// Module implements automatic updates hardening checks.
+type Module struct {
+	familyOverride string
+
+	aptSourcesListPath     string
+	aptSourcesListDir      string
+	aptAutoUpgradesPath    string
+	aptUnattendedPath      string
+	aptTrustedGPGPath      string
+	aptTrustedGPGDir       string
+	usrShareKeyringsDir    string
+	dnfAutomaticConfigPath string
+}
+
+func (m *Module) Name() string    { return "updates" }
+func (m *Module) Version() string { return "0.1.0" }
+
+// Audit evaluates update hardening controls for Debian-family and RHEL-family hosts.
+func (m *Module) Audit(_ context.Context, cfg modules.ModuleConfig) ([]modules.Finding, error) {
+	family := m.detectFamily(cfg)
+	if family == "" {
+		return []modules.Finding{
+			newSkippedFinding(checkUPD001(), "unknown", "debian/rhel", "could not detect package-manager family"),
+			newSkippedFinding(checkUPD002(), "unknown", "enabled", "could not detect package-manager family"),
+			newSkippedFinding(checkUPD003(), "unknown", "configured", "could not detect package-manager family"),
+			newSkippedFinding(checkUPD004(), "unknown", "configured", "could not detect package-manager family"),
+			newSkippedFinding(checkUPD005(), "unknown", "optional", "check applies to apt sources only"),
+		}, nil
+	}
+
+	findings := make([]modules.Finding, 0, 5)
+	findings = append(findings, m.auditGPGKeys(family))
+	findings = append(findings, m.auditSecurityRepo(family))
+	findings = append(findings, m.auditUnattended(family))
+	findings = append(findings, m.auditAutoReboot(family, cfgBool(cfg, "auto_reboot_after_kernel", false)))
+	findings = append(findings, m.auditLocalMirror(family))
+
+	return findings, nil
+}
+
+// Plan currently returns no changes; this module is audit-only in v0.1.
+func (m *Module) Plan(ctx context.Context, cfg modules.ModuleConfig) ([]modules.Change, error) {
+	_, err := m.Audit(ctx, cfg)
+	if err != nil {
+		return nil, err
+	}
+	return nil, nil
+}
+
+func (m *Module) detectFamily(cfg modules.ModuleConfig) string {
+	if f := strings.ToLower(strings.TrimSpace(cfgString(cfg, "family", m.familyOverride))); f != "" {
+		switch f {
+		case "debian", "apt", "ubuntu":
+			return "debian"
+		case "rhel", "dnf", "yum", "centos", "fedora", "rocky", "amzn", "almalinux":
+			return "rhel"
+		}
+	}
+
+	if fileExists(m.aptAutoPath()) || fileExists(m.aptUnattendedCfg()) || fileExists(m.aptSourcesPath()) {
+		return "debian"
+	}
+	if fileExists(m.dnfAutomaticPath()) {
+		return "rhel"
+	}
+
+	if dirHasEntries(m.aptSourcesDirPath()) {
+		return "debian"
+	}
+	return ""
+}
+
+func (m *Module) auditGPGKeys(family string) modules.Finding {
+	count := 0
+	paths := make([]string, 0, 8)
+
+	switch family {
+	case "debian":
+		for _, p := range []string{m.aptTrustedGPGPathValue(), m.aptTrustedGPGDirPath() + "/*.gpg", m.usrShareKeyringsPath() + "/*.gpg"} {
+			paths = append(paths, expandPath(p)...)
+		}
+	case "rhel":
+		paths = append(paths, expandPath("/etc/pki/rpm-gpg/RPM-GPG-KEY*")...)
+	}
+
+	for _, p := range paths {
+		if info, err := os.Stat(p); err == nil && !info.IsDir() && info.Size() > 0 {
+			count++
+		}
+	}
+
+	status := modules.StatusNonCompliant
+	if count > 0 {
+		status = modules.StatusCompliant
+	}
+
+	return modules.Finding{
+		Check:   checkUPD001(),
+		Status:  status,
+		Current: fmt.Sprintf("%d non-empty key files", count),
+		Target:  "at least 1 non-empty key file",
+		Detail:  fmt.Sprintf("family=%s", family),
+	}
+}
+
+func (m *Module) auditSecurityRepo(family string) modules.Finding {
+	switch family {
+	case "debian":
+		hasSecurity, detail := hasDebianSecurityRepo(m.aptSourcesPath(), m.aptSourcesDirPath())
+		return modules.Finding{
+			Check:   checkUPD002(),
+			Status:  complianceStatus(hasSecurity),
+			Current: detail,
+			Target:  "security repository enabled",
+			Detail:  "parsed apt sources for security repositories",
+		}
+	case "rhel":
+		cfg, err := parseKeyValueFile(m.dnfAutomaticPath())
+		if err != nil {
+			return newErrorFinding(checkUPD002(), "missing dnf automatic config", "upgrade_type=security", err)
+		}
+		upgradeType := strings.ToLower(strings.TrimSpace(cfg["upgrade_type"]))
+		ok := upgradeType == "security"
+		return modules.Finding{
+			Check:   checkUPD002(),
+			Status:  complianceStatus(ok),
+			Current: valueOrMissing(upgradeType),
+			Target:  "security",
+			Detail:  "dnf-automatic upgrade_type should be security",
+		}
+	default:
+		return newSkippedFinding(checkUPD002(), "unknown", "enabled", "unsupported package-manager family")
+	}
+}
+
+func (m *Module) auditUnattended(family string) modules.Finding {
+	switch family {
+	case "debian":
+		cfg, err := parseAptConfPairs(m.aptAutoPath())
+		if err != nil {
+			return newErrorFinding(checkUPD003(), "missing apt auto-upgrades config", "APT::Periodic::Unattended-Upgrade \"1\";", err)
+		}
+		val := strings.TrimSpace(cfg["apt::periodic::unattended-upgrade"])
+		ok := val == "1"
+		return modules.Finding{
+			Check:   checkUPD003(),
+			Status:  complianceStatus(ok),
+			Current: valueOrMissing(val),
+			Target:  "1",
+			Detail:  "APT::Periodic::Unattended-Upgrade must be enabled",
+		}
+	case "rhel":
+		cfg, err := parseKeyValueFile(m.dnfAutomaticPath())
+		if err != nil {
+			return newErrorFinding(checkUPD003(), "missing dnf automatic config", "apply_updates=yes", err)
+		}
+		val := strings.ToLower(strings.TrimSpace(cfg["apply_updates"]))
+		ok := val == "yes" || val == "true" || val == "1"
+		return modules.Finding{
+			Check:   checkUPD003(),
+			Status:  complianceStatus(ok),
+			Current: valueOrMissing(val),
+			Target:  "yes",
+			Detail:  "dnf-automatic apply_updates should be enabled",
+		}
+	default:
+		return newSkippedFinding(checkUPD003(), "unknown", "configured", "unsupported package-manager family")
+	}
+}
+
+func (m *Module) auditAutoReboot(family string, targetEnabled bool) modules.Finding {
+	target := "disabled"
+	if targetEnabled {
+		target = "enabled"
+	}
+
+	switch family {
+	case "debian":
+		cfg, err := parseAptConfPairs(m.aptUnattendedCfg())
+		if err != nil {
+			return newErrorFinding(checkUPD004(), "missing unattended-upgrades config", target, err)
+		}
+		current := strings.ToLower(strings.TrimSpace(cfg["unattended-upgrade::automatic-reboot"]))
+		currentEnabled := current == "true" || current == "1" || current == "yes"
+		return modules.Finding{
+			Check:   checkUPD004(),
+			Status:  complianceStatus(currentEnabled == targetEnabled),
+			Current: boolLabel(currentEnabled),
+			Target:  target,
+			Detail:  "Unattended-Upgrade::Automatic-Reboot is configurable via module config",
+		}
+	case "rhel":
+		cfg, err := parseKeyValueFile(m.dnfAutomaticPath())
+		if err != nil {
+			return newErrorFinding(checkUPD004(), "missing dnf automatic config", target, err)
+		}
+		current := strings.ToLower(strings.TrimSpace(cfg["reboot"]))
+		currentEnabled := current == "when-needed" || current == "yes" || current == "true" || current == "1"
+		return modules.Finding{
+			Check:   checkUPD004(),
+			Status:  complianceStatus(currentEnabled == targetEnabled),
+			Current: boolLabel(currentEnabled),
+			Target:  target,
+			Detail:  "dnf-automatic reboot should match module config",
+		}
+	default:
+		return newSkippedFinding(checkUPD004(), "unknown", target, "unsupported package-manager family")
+	}
+}
+
+func (m *Module) auditLocalMirror(family string) modules.Finding {
+	if family != "debian" {
+		return newSkippedFinding(checkUPD005(), family, "optional", "check applies to apt sources only")
+	}
+
+	local, detail := hasLocalAPTSource(m.aptSourcesPath(), m.aptSourcesDirPath())
+	status := modules.StatusManual
+	if local {
+		status = modules.StatusCompliant
+	}
+	return modules.Finding{
+		Check:   checkUPD005(),
+		Status:  status,
+		Current: detail,
+		Target:  "local mirror (optional)",
+		Detail:  "informational check",
+	}
+}
+
+func (m *Module) aptSourcesPath() string {
+	if m.aptSourcesListPath != "" {
+		return m.aptSourcesListPath
+	}
+	return defaultAPTSourceList
+}
+
+func (m *Module) aptSourcesDirPath() string {
+	if m.aptSourcesListDir != "" {
+		return m.aptSourcesListDir
+	}
+	return defaultAPTSourcesListDir
+}
+
+func (m *Module) aptAutoPath() string {
+	if m.aptAutoUpgradesPath != "" {
+		return m.aptAutoUpgradesPath
+	}
+	return defaultAPTAutoUpgradesPath
+}
+
+func (m *Module) aptUnattendedCfg() string {
+	if m.aptUnattendedPath != "" {
+		return m.aptUnattendedPath
+	}
+	return defaultAPTUnattendedPath
+}
+
+func (m *Module) aptTrustedGPGPathValue() string {
+	if m.aptTrustedGPGPath != "" {
+		return m.aptTrustedGPGPath
+	}
+	return defaultAPTTrustedGPG
+}
+
+func (m *Module) aptTrustedGPGDirPath() string {
+	if m.aptTrustedGPGDir != "" {
+		return m.aptTrustedGPGDir
+	}
+	return defaultAPTTrustedGPGDir
+}
+
+func (m *Module) usrShareKeyringsPath() string {
+	if m.usrShareKeyringsDir != "" {
+		return m.usrShareKeyringsDir
+	}
+	return defaultUSRShareKeyringsDir
+}
+
+func (m *Module) dnfAutomaticPath() string {
+	if m.dnfAutomaticConfigPath != "" {
+		return m.dnfAutomaticConfigPath
+	}
+	return defaultDNFAutomaticConf
+}
+
+func checkUPD001() modules.Check {
+	return modules.Check{
+		ID:       "upd-001",
+		Title:    "Package manager GPG keys configured",
+		Severity: modules.SeverityCritical,
+		Compliance: []modules.ComplianceRef{
+			{Framework: "CIS", Control: "1.2.1"},
+			{Framework: "NIST", Control: "SI-2"},
+		},
+	}
+}
+
+func checkUPD002() modules.Check {
+	return modules.Check{
+		ID:       "upd-002",
+		Title:    "Security updates repository enabled",
+		Severity: modules.SeverityHigh,
+		Compliance: []modules.ComplianceRef{
+			{Framework: "CIS", Control: "1.2.2"},
+			{Framework: "NIST", Control: "SI-2"},
+		},
+	}
+}
+
+func checkUPD003() modules.Check {
+	return modules.Check{
+		ID:       "upd-003",
+		Title:    "Unattended security upgrades configured",
+		Severity: modules.SeverityHigh,
+		Compliance: []modules.ComplianceRef{
+			{Framework: "CIS", Control: "1.9"},
+			{Framework: "NIST", Control: "SI-2"},
+		},
+	}
+}
+
+func checkUPD004() modules.Check {
+	return modules.Check{
+		ID:       "upd-004",
+		Title:    "Auto-reboot after kernel updates (configurable)",
+		Severity: modules.SeverityMedium,
+	}
+}
+
+func checkUPD005() modules.Check {
+	return modules.Check{
+		ID:       "upd-005",
+		Title:    "apt-get update via local mirror (optional)",
+		Severity: modules.SeverityInfo,
+	}
+}
+
+func hasDebianSecurityRepo(sourceListPath, sourceListDir string) (bool, string) {
+	entries := make([]string, 0)
+	for _, p := range append([]string{sourceListPath}, expandPath(filepath.Join(sourceListDir, "*.list"))...) {
+		lines := readNonCommentLines(p)
+		for _, line := range lines {
+			if isAPTSourceLine(line) && strings.Contains(strings.ToLower(line), "security") {
+				entries = append(entries, line)
+			}
+		}
+	}
+	if len(entries) == 0 {
+		return false, "no security source entries found"
+	}
+	return true, fmt.Sprintf("%d security source entries", len(entries))
+}
+
+func hasLocalAPTSource(sourceListPath, sourceListDir string) (bool, string) {
+	for _, p := range append([]string{sourceListPath}, expandPath(filepath.Join(sourceListDir, "*.list"))...) {
+		lines := readNonCommentLines(p)
+		for _, line := range lines {
+			if !isAPTSourceLine(line) {
+				continue
+			}
+			for _, tok := range strings.Fields(line) {
+				if strings.HasPrefix(tok, "[") {
+					continue
+				}
+				if !strings.Contains(tok, "://") && !strings.HasPrefix(tok, "file:") {
+					continue
+				}
+				if isLocalMirrorToken(tok) {
+					return true, fmt.Sprintf("local mirror source: %s", tok)
+				}
+				break
+			}
+		}
+	}
+	return false, "no local mirror source detected"
+}
+
+func isLocalMirrorToken(tok string) bool {
+	if strings.HasPrefix(tok, "file:") {
+		return true
+	}
+	u, err := url.Parse(tok)
+	if err != nil || u.Hostname() == "" {
+		return false
+	}
+	h := strings.ToLower(u.Hostname())
+	if h == "localhost" || strings.HasSuffix(h, ".local") || strings.HasSuffix(h, ".lan") || strings.HasSuffix(h, ".internal") || strings.HasSuffix(h, ".corp") {
+		return true
+	}
+	ip := net.ParseIP(h)
+	if ip == nil {
+		return false
+	}
+	privateBlocks := []string{"10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16", "127.0.0.0/8"}
+	for _, cidr := range privateBlocks {
+		_, network, _ := net.ParseCIDR(cidr)
+		if network.Contains(ip) {
+			return true
+		}
+	}
+	return false
+}
+
+func parseAptConfPairs(path string) (map[string]string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	out := make(map[string]string)
+	s := bufio.NewScanner(f)
+	for s.Scan() {
+		line := strings.TrimSpace(s.Text())
+		if line == "" || strings.HasPrefix(line, "//") || strings.HasPrefix(line, "#") {
+			continue
+		}
+		line = strings.TrimSuffix(line, ";")
+		parts := strings.Fields(line)
+		if len(parts) < 2 {
+			continue
+		}
+		key := strings.ToLower(strings.TrimSpace(parts[0]))
+		value := strings.Trim(strings.Join(parts[1:], " "), "\"")
+		out[key] = value
+	}
+	if err := s.Err(); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func parseKeyValueFile(path string) (map[string]string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	out := make(map[string]string)
+	s := bufio.NewScanner(f)
+	for s.Scan() {
+		line := strings.TrimSpace(s.Text())
+		if line == "" || strings.HasPrefix(line, "#") || strings.HasPrefix(line, ";") {
+			continue
+		}
+		if strings.HasPrefix(line, "[") && strings.HasSuffix(line, "]") {
+			continue
+		}
+		parts := strings.SplitN(line, "=", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		key := strings.ToLower(strings.TrimSpace(parts[0]))
+		value := strings.ToLower(strings.TrimSpace(parts[1]))
+		out[key] = value
+	}
+	if err := s.Err(); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func readNonCommentLines(path string) []string {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil
+	}
+	defer f.Close()
+
+	out := make([]string, 0)
+	s := bufio.NewScanner(f)
+	for s.Scan() {
+		line := strings.TrimSpace(s.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		out = append(out, line)
+	}
+	return out
+}
+
+func isAPTSourceLine(line string) bool {
+	l := strings.TrimSpace(strings.ToLower(line))
+	return strings.HasPrefix(l, "deb ") || strings.HasPrefix(l, "deb-src ")
+}
+
+func expandPath(pattern string) []string {
+	if strings.ContainsAny(pattern, "*?[") {
+		matches, _ := filepath.Glob(pattern)
+		return matches
+	}
+	return []string{pattern}
+}
+
+func complianceStatus(ok bool) modules.Status {
+	if ok {
+		return modules.StatusCompliant
+	}
+	return modules.StatusNonCompliant
+}
+
+func boolLabel(v bool) string {
+	if v {
+		return "enabled"
+	}
+	return "disabled"
+}
+
+func valueOrMissing(v string) string {
+	if strings.TrimSpace(v) == "" {
+		return "missing"
+	}
+	return v
+}
+
+func cfgString(cfg modules.ModuleConfig, key, fallback string) string {
+	if cfg != nil {
+		if val, ok := cfg[key]; ok {
+			s, ok := val.(string)
+			if ok {
+				return s
+			}
+		}
+	}
+	return fallback
+}
+
+func cfgBool(cfg modules.ModuleConfig, key string, fallback bool) bool {
+	if cfg != nil {
+		if val, ok := cfg[key]; ok {
+			if b, ok := val.(bool); ok {
+				return b
+			}
+		}
+	}
+	return fallback
+}
+
+func newSkippedFinding(chk modules.Check, current, target, detail string) modules.Finding {
+	return modules.Finding{Check: chk, Status: modules.StatusSkipped, Current: current, Target: target, Detail: detail}
+}
+
+func newErrorFinding(chk modules.Check, current, target string, err error) modules.Finding {
+	return modules.Finding{Check: chk, Status: modules.StatusError, Current: current, Target: target, Detail: err.Error()}
+}
+
+func fileExists(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && !info.IsDir()
+}
+
+func dirHasEntries(path string) bool {
+	entries, err := os.ReadDir(path)
+	return err == nil && len(entries) > 0
+}

--- a/internal/modules/updates/module_test.go
+++ b/internal/modules/updates/module_test.go
@@ -1,0 +1,159 @@
+package updates_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/hardbox-io/hardbox/internal/modules"
+	"github.com/hardbox-io/hardbox/internal/modules/updates"
+)
+
+func TestModule_ImplementsInterface(t *testing.T) {
+	var _ modules.Module = updates.NewModuleForTest(updates.TestOptions{})
+}
+
+func TestModule_NameAndVersion(t *testing.T) {
+	m := updates.NewModuleForTest(updates.TestOptions{})
+	if m.Name() != "updates" {
+		t.Fatalf("Name() = %q, want %q", m.Name(), "updates")
+	}
+	if m.Version() == "" {
+		t.Fatal("Version() should not be empty")
+	}
+}
+
+func TestAudit_Debian_Compliant(t *testing.T) {
+	tmp := t.TempDir()
+	paths := buildDebianFixture(t, tmp, true)
+
+	m := updates.NewModuleForTest(paths)
+	findings, err := m.Audit(context.Background(), modules.ModuleConfig{"auto_reboot_after_kernel": true})
+	if err != nil {
+		t.Fatalf("Audit(): %v", err)
+	}
+
+	assertStatus(t, findings, "upd-001", modules.StatusCompliant)
+	assertStatus(t, findings, "upd-002", modules.StatusCompliant)
+	assertStatus(t, findings, "upd-003", modules.StatusCompliant)
+	assertStatus(t, findings, "upd-004", modules.StatusCompliant)
+	assertStatus(t, findings, "upd-005", modules.StatusCompliant)
+}
+
+func TestAudit_RHEL_Compliant(t *testing.T) {
+	tmp := t.TempDir()
+	dnfPath := filepath.Join(tmp, "automatic.conf")
+	gpgDir := filepath.Join(tmp, "rpm-gpg")
+	if err := os.MkdirAll(gpgDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(gpgDir, "RPM-GPG-KEY-test"), []byte("key"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(dnfPath, []byte("[commands]\nupgrade_type = security\napply_updates = yes\nreboot = when-needed\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	m := updates.NewModuleForTest(updates.TestOptions{
+		Family:             "rhel",
+		DNFAutomaticConfig: dnfPath,
+	})
+	findings, err := m.Audit(context.Background(), modules.ModuleConfig{"auto_reboot_after_kernel": true})
+	if err != nil {
+		t.Fatalf("Audit(): %v", err)
+	}
+
+	assertStatus(t, findings, "upd-002", modules.StatusCompliant)
+	assertStatus(t, findings, "upd-003", modules.StatusCompliant)
+	assertStatus(t, findings, "upd-004", modules.StatusCompliant)
+}
+
+func TestAudit_Debian_MissingGPG_NonCompliant(t *testing.T) {
+	tmp := t.TempDir()
+	paths := buildDebianFixture(t, tmp, false)
+
+	m := updates.NewModuleForTest(paths)
+	findings, err := m.Audit(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("Audit(): %v", err)
+	}
+
+	assertStatus(t, findings, "upd-001", modules.StatusNonCompliant)
+}
+
+func TestPlan_AuditOnly(t *testing.T) {
+	tmp := t.TempDir()
+	paths := buildDebianFixture(t, tmp, true)
+
+	m := updates.NewModuleForTest(paths)
+	changes, err := m.Plan(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("Plan(): %v", err)
+	}
+	if len(changes) != 0 {
+		t.Fatalf("Plan(): got %d changes, want 0", len(changes))
+	}
+}
+
+func buildDebianFixture(t *testing.T, root string, withKey bool) updates.TestOptions {
+	t.Helper()
+	sourcesDir := filepath.Join(root, "sources.list.d")
+	aptConfDir := filepath.Join(root, "apt.conf.d")
+	trustedDir := filepath.Join(root, "trusted.gpg.d")
+	keyringsDir := filepath.Join(root, "keyrings")
+
+	for _, d := range []string{sourcesDir, aptConfDir, trustedDir, keyringsDir} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	sourcesPath := filepath.Join(root, "sources.list")
+	sourcesExtra := filepath.Join(sourcesDir, "security.list")
+	autoUpgrades := filepath.Join(aptConfDir, "20auto-upgrades")
+	unattended := filepath.Join(aptConfDir, "50unattended-upgrades")
+	trustedGPG := filepath.Join(root, "trusted.gpg")
+
+	if err := os.WriteFile(sourcesPath, []byte("deb http://archive.ubuntu.com/ubuntu jammy main\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(sourcesExtra, []byte("deb http://mirror.internal/ubuntu jammy-security main\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(autoUpgrades, []byte("APT::Periodic::Unattended-Upgrade \"1\";\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(unattended, []byte("Unattended-Upgrade::Automatic-Reboot \"true\";\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if withKey {
+		if err := os.WriteFile(trustedGPG, []byte("key"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	return updates.TestOptions{
+		Family:            "debian",
+		APTSourcesList:    sourcesPath,
+		APTSourcesListDir: sourcesDir,
+		APTAutoUpgrades:   autoUpgrades,
+		APTUnattended:     unattended,
+		APTTrustedGPG:     trustedGPG,
+		APTTrustedGPGDir:  trustedDir,
+		USRShareKeyrings:  keyringsDir,
+	}
+}
+
+func assertStatus(t *testing.T, findings []modules.Finding, id string, want modules.Status) {
+	t.Helper()
+	for _, f := range findings {
+		if f.Check.ID == id {
+			if f.Status != want {
+				t.Fatalf("check %s status = %s, want %s", id, f.Status, want)
+			}
+			return
+		}
+	}
+	t.Fatalf("check %s not found", id)
+}


### PR DESCRIPTION
## What
Implement the automatic updates module with checks upd-001..upd-005 for Debian-family and RHEL-family systems.

## Why
Fixes #18

## How
- add new module at internal/modules/updates with audit checks:
  - upd-001: package manager GPG keys configured
  - upd-002: security updates repository enabled
  - upd-003: unattended security upgrades configured
  - upd-004: auto-reboot after kernel updates (configurable)
  - upd-005: apt local mirror (optional/info)
- add test constructor to inject family and file paths for deterministic tests
- add module tests for Debian and RHEL compliant scenarios and missing-key non-compliance
- register updates module in engine registry
- add compliance mapping for upd-001..upd-005

## Testing
- [x] go test ./internal/modules/updates
- [x] go test ./internal/engine

## Notes
- Plan() is audit-only in this v0.1 implementation and returns no changes.