### PR TITLE
feat(mac): implement apparmor and selinux checks

### DIFF
--- a/docs/COMPLIANCE.md
+++ b/docs/COMPLIANCE.md
@@ -157,6 +157,8 @@ This document is the authoritative cross-reference index.
 | mac-001 | AppArmor/SELinux installed | 1.6.1 | AC-3 | V-238332 | A.9.4.5 |
 | mac-002 | Enabled at boot | 1.6.2 | AC-3 | V-238333 | A.9.4.5 |
 | mac-003 | Enforcing mode | 1.6.3 | AC-3 | V-238334 | A.9.4.5 |
+| mac-004 | No unconfined processes (AppArmor) | 1.6.4 | AC-3 | — | A.9.4.5 |
+| mac-005 | SELinux policy type targeted or mls | — | AC-3 | V-238335 | A.9.4.5 |
 
 ---
 

--- a/internal/engine/registry.go
+++ b/internal/engine/registry.go
@@ -4,6 +4,7 @@ import (
 	"github.com/hardbox-io/hardbox/internal/modules"
 	"github.com/hardbox-io/hardbox/internal/modules/filesystem"
 	"github.com/hardbox-io/hardbox/internal/modules/kernel"
+	"github.com/hardbox-io/hardbox/internal/modules/mac"
 	"github.com/hardbox-io/hardbox/internal/modules/ntp"
 	"github.com/hardbox-io/hardbox/internal/modules/services"
 	"github.com/hardbox-io/hardbox/internal/modules/updates"
@@ -17,6 +18,7 @@ func registeredModules() []modules.Module {
 	return []modules.Module{
 		&kernel.Module{},
 		&filesystem.Module{},
+		&mac.Module{},
 		&ntp.Module{},
 		&services.Module{},
 		&updates.Module{},
@@ -28,7 +30,6 @@ func registeredModules() []modules.Module {
 		// &pam.Module{},
 		// &auditd.Module{},
 		// &logging.Module{},
-		// &mac.Module{},
 		// &crypto.Module{},
 		// &containers.Module{},
 	}

--- a/internal/modules/mac/export_test.go
+++ b/internal/modules/mac/export_test.go
@@ -1,0 +1,21 @@
+package mac
+
+import "context"
+
+// TestOptions customizes module internals for tests.
+type TestOptions struct {
+	Backend          string
+	SELinuxConfig    string
+	AppArmorEnabled  string
+	Runner           func(ctx context.Context, name string, args ...string) (string, error)
+}
+
+// NewModuleForTest returns a Module with injected test hooks.
+func NewModuleForTest(o TestOptions) *Module {
+	return &Module{
+		run:             o.Runner,
+		backendOverride: o.Backend,
+		selinuxConfig:   o.SELinuxConfig,
+		apparmorEnabled: o.AppArmorEnabled,
+	}
+}

--- a/internal/modules/mac/module.go
+++ b/internal/modules/mac/module.go
@@ -1,0 +1,302 @@
+package mac
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/hardbox-io/hardbox/internal/distro"
+	"github.com/hardbox-io/hardbox/internal/modules"
+)
+
+const defaultSELinuxConfig = "/etc/selinux/config"
+
+// backendType identifies the MAC backend on the host.
+type backendType string
+
+const (
+	backendUnknown   backendType = "unknown"
+	backendAppArmor backendType = "apparmor"
+	backendSELinux  backendType = "selinux"
+)
+
+type commandRunner func(ctx context.Context, name string, args ...string) (string, error)
+
+// Module implements Mandatory Access Control checks.
+type Module struct {
+	run commandRunner
+
+	backendOverride string
+	selinuxConfig   string
+	apparmorEnabled string
+}
+
+func (m *Module) Name() string    { return "mac" }
+func (m *Module) Version() string { return "0.1.0" }
+
+func (m *Module) runner() commandRunner {
+	if m.run != nil {
+		return m.run
+	}
+	return runCommand
+}
+
+func runCommand(ctx context.Context, name string, args ...string) (string, error) {
+	out, err := exec.CommandContext(ctx, name, args...).CombinedOutput() //nolint:gosec
+	return strings.TrimSpace(string(out)), err
+}
+
+// Audit evaluates MAC controls for AppArmor or SELinux.
+func (m *Module) Audit(ctx context.Context, cfg modules.ModuleConfig) ([]modules.Finding, error) {
+	backend := m.detectBackend(cfg)
+	switch backend {
+	case backendAppArmor:
+		return m.auditAppArmor(ctx)
+	case backendSELinux:
+		return m.auditSELinux(ctx)
+	default:
+		return []modules.Finding{
+			newSkipped(checkMAC001(), "unknown", "apparmor/selinux", "unable to detect MAC backend"),
+			newSkipped(checkMAC002(), "unknown", "enabled", "unable to detect MAC backend"),
+			newSkipped(checkMAC003(), "unknown", "enforcing", "unable to detect MAC backend"),
+			newSkipped(checkMAC004(), "unknown", "0", "only applicable to AppArmor"),
+			newSkipped(checkMAC005(), "unknown", "targeted or mls", "only applicable to SELinux"),
+		}, nil
+	}
+}
+
+// Plan is audit-only in v0.1.
+func (m *Module) Plan(ctx context.Context, cfg modules.ModuleConfig) ([]modules.Change, error) {
+	_, err := m.Audit(ctx, cfg)
+	if err != nil {
+		return nil, err
+	}
+	return nil, nil
+}
+
+func (m *Module) detectBackend(cfg modules.ModuleConfig) backendType {
+	override := strings.ToLower(strings.TrimSpace(cfgString(cfg, "backend", m.backendOverride)))
+	switch override {
+	case "apparmor":
+		return backendAppArmor
+	case "selinux":
+		return backendSELinux
+	}
+
+	if info, err := distro.Detect(); err == nil {
+		switch info.Family {
+		case distro.FamilyDebian:
+			return backendAppArmor
+		case distro.FamilyRHEL:
+			return backendSELinux
+		}
+	}
+
+	if _, err := os.Stat(m.selinuxConfigPath()); err == nil {
+		return backendSELinux
+	}
+	if _, err := os.Stat(m.apparmorEnabledPath()); err == nil {
+		return backendAppArmor
+	}
+	return backendUnknown
+}
+
+func (m *Module) auditAppArmor(ctx context.Context) ([]modules.Finding, error) {
+	out, err := m.runner()(ctx, "aa-status")
+	if err != nil {
+		return []modules.Finding{
+			{Check: checkMAC001(), Status: modules.StatusNonCompliant, Current: "aa-status failed", Target: "installed", Detail: strings.TrimSpace(out)},
+			newSkipped(checkMAC002(), "unknown", "enabled", "aa-status unavailable"),
+			newSkipped(checkMAC003(), "unknown", "enforcing", "aa-status unavailable"),
+			newSkipped(checkMAC004(), "unknown", "0", "aa-status unavailable"),
+			newSkipped(checkMAC005(), "n/a", "targeted or mls", "SELinux-only check"),
+		}, nil
+	}
+
+	enabledRaw, enabledErr := os.ReadFile(m.apparmorEnabledPath())
+	enabled := enabledErr == nil && strings.EqualFold(strings.TrimSpace(string(enabledRaw)), "Y")
+	enforcing := parseAANumber(out, "profiles are in enforce mode") > 0
+	unconfined := parseAANumber(out, "processes are unconfined")
+	if unconfined < 0 {
+		unconfined = parseAANumber(out, "processes are unconfined but have a profile defined")
+	}
+	if unconfined < 0 {
+		unconfined = 0
+	}
+
+	return []modules.Finding{
+		{Check: checkMAC001(), Status: modules.StatusCompliant, Current: "aa-status available", Target: "installed", Detail: "AppArmor userspace tooling detected"},
+		{Check: checkMAC002(), Status: complianceStatus(enabled), Current: boolLabel(enabled), Target: "enabled", Detail: "read /sys/module/apparmor/parameters/enabled"},
+		{Check: checkMAC003(), Status: complianceStatus(enforcing), Current: fmt.Sprintf("%d profiles enforcing", parseAANumber(out, "profiles are in enforce mode")), Target: ">= 1 enforcing profile", Detail: "parsed aa-status output"},
+		{Check: checkMAC004(), Status: complianceStatus(unconfined == 0), Current: fmt.Sprintf("%d unconfined", unconfined), Target: "0", Detail: "parsed aa-status output"},
+		newSkipped(checkMAC005(), "n/a", "targeted or mls", "SELinux-only check"),
+	}, nil
+}
+
+func (m *Module) auditSELinux(ctx context.Context) ([]modules.Finding, error) {
+	out, err := m.runner()(ctx, "sestatus")
+	config := readSELinuxConfig(m.selinuxConfigPath())
+	if err != nil {
+		return []modules.Finding{
+			{Check: checkMAC001(), Status: modules.StatusNonCompliant, Current: "sestatus failed", Target: "installed", Detail: strings.TrimSpace(out)},
+			newSkipped(checkMAC002(), "unknown", "enabled", "sestatus unavailable"),
+			newSkipped(checkMAC003(), "unknown", "enforcing", "sestatus unavailable"),
+			newSkipped(checkMAC004(), "n/a", "0", "AppArmor-only check"),
+			newSkipped(checkMAC005(), "unknown", "targeted or mls", "sestatus unavailable"),
+		}, nil
+	}
+
+	status := strings.ToLower(parseStatusValue(out, "SELinux status"))
+	currentMode := strings.ToLower(parseStatusValue(out, "Current mode"))
+	loadedPolicy := strings.ToLower(parseStatusValue(out, "Loaded policy name"))
+	cfgMode := strings.ToLower(config["selinux"])
+	cfgType := strings.ToLower(config["selinuxtype"])
+
+	enabled := status == "enabled" && cfgMode != "disabled"
+	enforcing := currentMode == "enforcing"
+	policy := loadedPolicy
+	if policy == "" {
+		policy = cfgType
+	}
+	policyOk := policy == "targeted" || policy == "mls"
+
+	return []modules.Finding{
+		{Check: checkMAC001(), Status: modules.StatusCompliant, Current: "sestatus available", Target: "installed", Detail: "SELinux userspace tooling detected"},
+		{Check: checkMAC002(), Status: complianceStatus(enabled), Current: valueOrUnknown(boolLabel(enabled), status == ""), Target: "enabled", Detail: fmt.Sprintf("SELinux status=%q, config SELINUX=%q", status, cfgMode)},
+		{Check: checkMAC003(), Status: complianceStatus(enforcing), Current: valueOrUnknown(currentMode, currentMode == ""), Target: "enforcing", Detail: "parsed sestatus output"},
+		newSkipped(checkMAC004(), "n/a", "0", "AppArmor-only check"),
+		{Check: checkMAC005(), Status: complianceStatus(policyOk), Current: valueOrUnknown(policy, policy == ""), Target: "targeted or mls", Detail: fmt.Sprintf("SELINUXTYPE=%q", cfgType)},
+	}, nil
+}
+
+func (m *Module) selinuxConfigPath() string {
+	if m.selinuxConfig != "" {
+		return m.selinuxConfig
+	}
+	return defaultSELinuxConfig
+}
+
+func (m *Module) apparmorEnabledPath() string {
+	if m.apparmorEnabled != "" {
+		return m.apparmorEnabled
+	}
+	return "/sys/module/apparmor/parameters/enabled"
+}
+
+func checkMAC001() modules.Check {
+	return modules.Check{ID: "mac-001", Title: "AppArmor / SELinux is installed", Severity: modules.SeverityCritical, Compliance: []modules.ComplianceRef{{Framework: "CIS", Control: "1.6.1"}, {Framework: "STIG", Control: "V-238332"}}}
+}
+
+func checkMAC002() modules.Check {
+	return modules.Check{ID: "mac-002", Title: "AppArmor / SELinux is enabled at boot", Severity: modules.SeverityCritical, Compliance: []modules.ComplianceRef{{Framework: "CIS", Control: "1.6.2"}, {Framework: "STIG", Control: "V-238333"}}}
+}
+
+func checkMAC003() modules.Check {
+	return modules.Check{ID: "mac-003", Title: "All profiles/policies are in enforcing mode", Severity: modules.SeverityHigh, Compliance: []modules.ComplianceRef{{Framework: "CIS", Control: "1.6.3"}, {Framework: "STIG", Control: "V-238334"}}}
+}
+
+func checkMAC004() modules.Check {
+	return modules.Check{ID: "mac-004", Title: "No unconfined processes (AppArmor)", Severity: modules.SeverityHigh, Compliance: []modules.ComplianceRef{{Framework: "CIS", Control: "1.6.4"}}}
+}
+
+func checkMAC005() modules.Check {
+	return modules.Check{ID: "mac-005", Title: "SELinux policy type is targeted or mls", Severity: modules.SeverityHigh, Compliance: []modules.ComplianceRef{{Framework: "STIG", Control: "V-238335"}}}
+}
+
+func parseAANumber(output, phrase string) int {
+	s := bufio.NewScanner(strings.NewReader(output))
+	needle := strings.ToLower(phrase)
+	for s.Scan() {
+		line := strings.ToLower(strings.TrimSpace(s.Text()))
+		if !strings.Contains(line, needle) {
+			continue
+		}
+		parts := strings.Fields(line)
+		if len(parts) == 0 {
+			return -1
+		}
+		var n int
+		if _, err := fmt.Sscanf(parts[0], "%d", &n); err == nil {
+			return n
+		}
+	}
+	return -1
+}
+
+func parseStatusValue(output, key string) string {
+	s := bufio.NewScanner(strings.NewReader(output))
+	for s.Scan() {
+		line := s.Text()
+		if !strings.Contains(strings.ToLower(line), strings.ToLower(key)) {
+			continue
+		}
+		parts := strings.SplitN(line, ":", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		return strings.TrimSpace(parts[1])
+	}
+	return ""
+}
+
+func readSELinuxConfig(path string) map[string]string {
+	out := map[string]string{}
+	f, err := os.Open(path)
+	if err != nil {
+		return out
+	}
+	defer f.Close()
+
+	s := bufio.NewScanner(f)
+	for s.Scan() {
+		line := strings.TrimSpace(s.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		parts := strings.SplitN(line, "=", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		out[strings.ToLower(strings.TrimSpace(parts[0]))] = strings.TrimSpace(parts[1])
+	}
+	return out
+}
+
+func complianceStatus(ok bool) modules.Status {
+	if ok {
+		return modules.StatusCompliant
+	}
+	return modules.StatusNonCompliant
+}
+
+func boolLabel(v bool) string {
+	if v {
+		return "enabled"
+	}
+	return "disabled"
+}
+
+func valueOrUnknown(v string, unknown bool) string {
+	if unknown || strings.TrimSpace(v) == "" {
+		return "unknown"
+	}
+	return v
+}
+
+func cfgString(cfg modules.ModuleConfig, key, fallback string) string {
+	if cfg != nil {
+		if val, ok := cfg[key]; ok {
+			if s, ok := val.(string); ok {
+				return s
+			}
+		}
+	}
+	return fallback
+}
+
+func newSkipped(chk modules.Check, current, target, detail string) modules.Finding {
+	return modules.Finding{Check: chk, Status: modules.StatusSkipped, Current: current, Target: target, Detail: detail}
+}

--- a/internal/modules/mac/module_test.go
+++ b/internal/modules/mac/module_test.go
@@ -1,0 +1,156 @@
+package mac_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/hardbox-io/hardbox/internal/modules"
+	"github.com/hardbox-io/hardbox/internal/modules/mac"
+)
+
+type fakeResult struct {
+	out string
+	err bool
+}
+
+func fakeRunner(results map[string]fakeResult) func(context.Context, string, ...string) (string, error) {
+	return func(_ context.Context, name string, args ...string) (string, error) {
+		key := strings.TrimSpace(name + " " + strings.Join(args, " "))
+		res, ok := results[key]
+		if !ok {
+			return "", fmt.Errorf("unexpected command: %s", key)
+		}
+		if res.err {
+			return res.out, fmt.Errorf("failed: %s", key)
+		}
+		return res.out, nil
+	}
+}
+
+func TestModule_ImplementsInterface(t *testing.T) {
+	var _ modules.Module = mac.NewModuleForTest(mac.TestOptions{})
+}
+
+func TestModule_NameAndVersion(t *testing.T) {
+	m := mac.NewModuleForTest(mac.TestOptions{})
+	if m.Name() != "mac" {
+		t.Fatalf("Name()=%q, want mac", m.Name())
+	}
+	if m.Version() == "" {
+		t.Fatal("Version() should not be empty")
+	}
+}
+
+func TestAudit_AppArmor_Compliant(t *testing.T) {
+	tmp := t.TempDir()
+	enabledPath := filepath.Join(tmp, "apparmor-enabled")
+	if err := os.WriteFile(enabledPath, []byte("Y\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	m := mac.NewModuleForTest(mac.TestOptions{
+		Backend:         "apparmor",
+		AppArmorEnabled: enabledPath,
+		Runner: fakeRunner(map[string]fakeResult{
+			"aa-status": {out: "17 profiles are loaded.\n17 profiles are in enforce mode.\n0 profiles are in complain mode.\n0 processes are unconfined but have a profile defined.\n"},
+		}),
+	})
+
+	findings, err := m.Audit(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("Audit: %v", err)
+	}
+	assertStatus(t, findings, "mac-001", modules.StatusCompliant)
+	assertStatus(t, findings, "mac-002", modules.StatusCompliant)
+	assertStatus(t, findings, "mac-003", modules.StatusCompliant)
+	assertStatus(t, findings, "mac-004", modules.StatusCompliant)
+	assertStatus(t, findings, "mac-005", modules.StatusSkipped)
+}
+
+func TestAudit_SELinux_Compliant(t *testing.T) {
+	tmp := t.TempDir()
+	cfgPath := filepath.Join(tmp, "selinux-config")
+	if err := os.WriteFile(cfgPath, []byte("SELINUX=enforcing\nSELINUXTYPE=targeted\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	m := mac.NewModuleForTest(mac.TestOptions{
+		Backend:       "selinux",
+		SELinuxConfig: cfgPath,
+		Runner: fakeRunner(map[string]fakeResult{
+			"sestatus": {out: "SELinux status:                 enabled\nCurrent mode:                   enforcing\nLoaded policy name:             targeted\n"},
+		}),
+	})
+
+	findings, err := m.Audit(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("Audit: %v", err)
+	}
+	assertStatus(t, findings, "mac-001", modules.StatusCompliant)
+	assertStatus(t, findings, "mac-002", modules.StatusCompliant)
+	assertStatus(t, findings, "mac-003", modules.StatusCompliant)
+	assertStatus(t, findings, "mac-004", modules.StatusSkipped)
+	assertStatus(t, findings, "mac-005", modules.StatusCompliant)
+}
+
+func TestAudit_AppArmor_NonCompliantUnconfined(t *testing.T) {
+	tmp := t.TempDir()
+	enabledPath := filepath.Join(tmp, "apparmor-enabled")
+	if err := os.WriteFile(enabledPath, []byte("N\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	m := mac.NewModuleForTest(mac.TestOptions{
+		Backend:         "apparmor",
+		AppArmorEnabled: enabledPath,
+		Runner: fakeRunner(map[string]fakeResult{
+			"aa-status": {out: "12 profiles are loaded.\n0 profiles are in enforce mode.\n4 processes are unconfined.\n"},
+		}),
+	})
+
+	findings, err := m.Audit(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("Audit: %v", err)
+	}
+	assertStatus(t, findings, "mac-002", modules.StatusNonCompliant)
+	assertStatus(t, findings, "mac-003", modules.StatusNonCompliant)
+	assertStatus(t, findings, "mac-004", modules.StatusNonCompliant)
+}
+
+func TestPlan_AuditOnly(t *testing.T) {
+	tmp := t.TempDir()
+	enabledPath := filepath.Join(tmp, "apparmor-enabled")
+	if err := os.WriteFile(enabledPath, []byte("Y\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	m := mac.NewModuleForTest(mac.TestOptions{
+		Backend:         "apparmor",
+		AppArmorEnabled: enabledPath,
+		Runner: fakeRunner(map[string]fakeResult{
+			"aa-status": {out: "1 profiles are in enforce mode.\n0 processes are unconfined.\n"},
+		}),
+	})
+
+	changes, err := m.Plan(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("Plan: %v", err)
+	}
+	if len(changes) != 0 {
+		t.Fatalf("Plan returned %d changes, want 0", len(changes))
+	}
+}
+
+func assertStatus(t *testing.T, findings []modules.Finding, id string, want modules.Status) {
+	t.Helper()
+	for _, f := range findings {
+		if f.Check.ID == id {
+			if f.Status != want {
+				t.Fatalf("%s: got %s, want %s", id, f.Status, want)
+			}
+			return
+		}
+	}
+	t.Fatalf("check %s not found", id)
+}


### PR DESCRIPTION
## What
Implementa el modulo MAC (`mac`) con soporte para AppArmor y SELinux.

## Why
Fixes #16

## How
- agrega `internal/modules/mac` con checks `mac-001` a `mac-005`
- backend AppArmor via `aa-status` y `/sys/module/apparmor/parameters/enabled`
- backend SELinux via `sestatus` y `/etc/selinux/config`
- registra el modulo en `internal/engine/registry.go`
- actualiza mapeo de compliance para `mac-004` y `mac-005`

## Testing
- [x] `go test ./internal/modules/mac`
- [x] `go test ./internal/engine`
- [ ] `go vet ./...`
- [ ] `golangci-lint run`
- [ ] `go test ./... -race`