### PR TITLE
feat(firewall): implement multi-backend firewall auditing module

### DIFF
--- a/docs/COMPLIANCE.md
+++ b/docs/COMPLIANCE.md
@@ -45,7 +45,10 @@ This document is the authoritative cross-reference index.
 |---|---|---|---|---|---|---|---|
 | fw-001 | Firewall enabled | 3.5.1 | SC-7 | V-238270 | 1.3.1 | 164.312(e)(1) | A.13.1.1 |
 | fw-002 | Default inbound DROP | 3.5.1.1 | SC-7 | V-238270 | 1.3.2 | 164.312(e)(1) | A.13.1.1 |
+| fw-003 | Default outbound DROP or ACCEPT | 3.5.1.2 | SC-7 | — | 1.3.3 | 164.312(e)(1) | A.13.1.1 |
+| fw-004 | Loopback traffic explicitly allowed | 3.5.1.3 | SC-7 | — | 1.3.2 | 164.312(e)(1) | A.13.1.1 |
 | fw-005 | No overly permissive rules | 3.5.1.4 | SC-7 | — | 1.3.4 | 164.312(e)(1) | A.13.1.1 |
+| fw-006 | IPv6 rules present when IPv6 enabled | 3.5.2 | SC-7 | — | 1.3.1 | 164.312(e)(1) | A.13.1.1 |
 
 ---
 

--- a/internal/engine/registry.go
+++ b/internal/engine/registry.go
@@ -3,6 +3,7 @@ package engine
 import (
 	"github.com/hardbox-io/hardbox/internal/modules"
 	"github.com/hardbox-io/hardbox/internal/modules/auditd"
+	"github.com/hardbox-io/hardbox/internal/modules/firewall"
 	"github.com/hardbox-io/hardbox/internal/modules/filesystem"
 	"github.com/hardbox-io/hardbox/internal/modules/kernel"
 	"github.com/hardbox-io/hardbox/internal/modules/logging"
@@ -30,9 +31,9 @@ func registeredModules() []modules.Module {
 		&auditd.Module{},
 		&logging.Module{},
 		&users.Module{},
+		&firewall.Module{},
 		// Stub placeholders — each will be fully implemented in its own package.
 		// &ssh.Module{},
-		// &firewall.Module{},
 		// &pam.Module{},
 		// &crypto.Module{},
 		// &containers.Module{},

--- a/internal/modules/firewall/checks.go
+++ b/internal/modules/firewall/checks.go
@@ -1,0 +1,69 @@
+package firewall
+
+import "github.com/hardbox-io/hardbox/internal/modules"
+
+func checkFW001() modules.Check {
+	return modules.Check{
+		ID:          "fw-001",
+		Title:       "Firewall service enabled and active",
+		Description: "Verify a supported firewall backend is installed and active.",
+		Remediation: "Enable and start ufw, firewalld, or nftables.",
+		Severity:    modules.SeverityCritical,
+		Compliance: []modules.ComplianceRef{{Framework: "CIS", Control: "3.5.1"}, {Framework: "NIST", Control: "SC-7"}, {Framework: "STIG", Control: "V-238270"}, {Framework: "PCI", Control: "1.3.1"}},
+	}
+}
+
+func checkFW002() modules.Check {
+	return modules.Check{
+		ID:          "fw-002",
+		Title:       "Default inbound policy is DROP",
+		Description: "Validate the default inbound traffic policy is deny/drop.",
+		Remediation: "Set default inbound policy to DROP.",
+		Severity:    modules.SeverityCritical,
+		Compliance: []modules.ComplianceRef{{Framework: "CIS", Control: "3.5.1.1"}, {Framework: "NIST", Control: "SC-7"}, {Framework: "PCI", Control: "1.3.2"}},
+	}
+}
+
+func checkFW003() modules.Check {
+	return modules.Check{
+		ID:          "fw-003",
+		Title:       "Default outbound policy is DROP or ACCEPT",
+		Description: "Validate outbound policy is explicitly set to DROP or ACCEPT.",
+		Remediation: "Set explicit outbound default policy.",
+		Severity:    modules.SeverityHigh,
+		Compliance: []modules.ComplianceRef{{Framework: "CIS", Control: "3.5.1.2"}, {Framework: "NIST", Control: "SC-7"}},
+	}
+}
+
+func checkFW004() modules.Check {
+	return modules.Check{
+		ID:          "fw-004",
+		Title:       "Loopback traffic explicitly allowed",
+		Description: "Ensure localhost traffic is explicitly allowed by firewall rules.",
+		Remediation: "Allow loopback input/output traffic.",
+		Severity:    modules.SeverityMedium,
+		Compliance: []modules.ComplianceRef{{Framework: "CIS", Control: "3.5.1.3"}, {Framework: "NIST", Control: "SC-7"}},
+	}
+}
+
+func checkFW005() modules.Check {
+	return modules.Check{
+		ID:          "fw-005",
+		Title:       "No overly permissive sensitive port rules",
+		Description: "Detect globally exposed sensitive ports from untrusted sources.",
+		Remediation: "Restrict sensitive ports by source CIDR or disable unnecessary services.",
+		Severity:    modules.SeverityHigh,
+		Compliance: []modules.ComplianceRef{{Framework: "CIS", Control: "3.5.1.4"}, {Framework: "NIST", Control: "SC-7"}, {Framework: "PCI", Control: "1.3.4"}},
+	}
+}
+
+func checkFW006() modules.Check {
+	return modules.Check{
+		ID:          "fw-006",
+		Title:       "IPv6 rules present when IPv6 enabled",
+		Description: "Ensure firewall coverage also exists for IPv6 traffic when enabled.",
+		Remediation: "Enable IPv6 filtering in the selected firewall backend.",
+		Severity:    modules.SeverityHigh,
+		Compliance: []modules.ComplianceRef{{Framework: "CIS", Control: "3.5.2"}, {Framework: "NIST", Control: "SC-7"}},
+	}
+}

--- a/internal/modules/firewall/export_test.go
+++ b/internal/modules/firewall/export_test.go
@@ -1,0 +1,33 @@
+package firewall
+
+import "github.com/hardbox-io/hardbox/internal/distro"
+
+// NewModuleForTest builds a firewall module with injectable dependencies.
+func NewModuleForTest(
+	run commandRunner,
+	detect distroDetector,
+	hasBinary binaryChecker,
+	backendOverride string,
+	ipv6DisablePath string,
+) *Module {
+	return &Module{
+		run:             run,
+		detectDistro:    detect,
+		hasBinary:       hasBinary,
+		backendOverride: backend(backendOverride),
+		ipv6DisablePath: ipv6DisablePath,
+	}
+}
+
+var (
+	ParseUFWDefaults = parseUFWDefaults
+	NftHasIPv6Rules  = nftHasIPv6Rules
+)
+
+func FakeDistroDebian() (*distro.Info, error) {
+	return &distro.Info{ID: "ubuntu", Family: distro.FamilyDebian}, nil
+}
+
+func FakeDistroRHEL() (*distro.Info, error) {
+	return &distro.Info{ID: "rocky", Family: distro.FamilyRHEL}, nil
+}

--- a/internal/modules/firewall/module.go
+++ b/internal/modules/firewall/module.go
@@ -1,0 +1,483 @@
+package firewall
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"regexp"
+	"strings"
+
+	"github.com/hardbox-io/hardbox/internal/distro"
+	"github.com/hardbox-io/hardbox/internal/modules"
+)
+
+const defaultIPv6DisablePath = "/proc/sys/net/ipv6/conf/all/disable_ipv6"
+
+type commandRunner func(ctx context.Context, name string, args ...string) (string, error)
+type distroDetector func() (*distro.Info, error)
+type binaryChecker func(name string) bool
+
+type backend string
+
+const (
+	backendUFW       backend = "ufw"
+	backendFirewalld backend = "firewalld"
+	backendNftables  backend = "nftables"
+)
+
+type auditState struct {
+	backend backend
+
+	serviceKnown  bool
+	serviceActive bool
+	serviceDetail string
+
+	inboundKnown bool
+	inboundDrop  bool
+	inboundValue string
+
+	outboundKnown bool
+	outboundOK    bool
+	outboundValue string
+
+	loopbackKnown   bool
+	loopbackAllowed bool
+	loopbackValue   string
+
+	permissiveKnown bool
+	permissiveFound bool
+	permissiveValue string
+
+	ipv6RulesKnown bool
+	ipv6RulesFound bool
+	ipv6Value      string
+}
+
+// Module implements firewall hardening checks for UFW, firewalld, and nftables.
+type Module struct {
+	run             commandRunner
+	detectDistro    distroDetector
+	hasBinary       binaryChecker
+	backendOverride backend
+	ipv6DisablePath string
+}
+
+func (m *Module) Name() string    { return "firewall" }
+func (m *Module) Version() string { return "0.1.0" }
+
+func (m *Module) runner() commandRunner {
+	if m.run != nil {
+		return m.run
+	}
+	return runCommand
+}
+
+func (m *Module) detector() distroDetector {
+	if m.detectDistro != nil {
+		return m.detectDistro
+	}
+	return distro.Detect
+}
+
+func (m *Module) binaryExists() binaryChecker {
+	if m.hasBinary != nil {
+		return m.hasBinary
+	}
+	return func(name string) bool {
+		_, err := exec.LookPath(name)
+		return err == nil
+	}
+}
+
+func (m *Module) ipv6Path() string {
+	if m.ipv6DisablePath != "" {
+		return m.ipv6DisablePath
+	}
+	return defaultIPv6DisablePath
+}
+
+// Audit executes backend-specific parsing and returns firewall findings.
+func (m *Module) Audit(ctx context.Context, _ modules.ModuleConfig) ([]modules.Finding, error) {
+	selected, err := m.detectBackend()
+	if err != nil {
+		return m.errorFindings(err), nil
+	}
+
+	state, err := m.auditBackend(ctx, selected)
+	if err != nil {
+		return m.errorFindings(err), nil
+	}
+
+	ipv6Enabled := m.isIPv6Enabled()
+
+	findings := make([]modules.Finding, 0, 6)
+	findings = append(findings, m.findingService(state))
+	findings = append(findings, m.findingInbound(state))
+	findings = append(findings, m.findingOutbound(state))
+	findings = append(findings, m.findingLoopback(state))
+	findings = append(findings, m.findingPermissive(state))
+	findings = append(findings, m.findingIPv6(state, ipv6Enabled))
+	return findings, nil
+}
+
+// Plan is intentionally read-only for now; remediation differs heavily by backend.
+func (m *Module) Plan(_ context.Context, _ modules.ModuleConfig) ([]modules.Change, error) {
+	return nil, nil
+}
+
+func (m *Module) detectBackend() (backend, error) {
+	if m.backendOverride != "" {
+		return m.backendOverride, nil
+	}
+	if info, err := m.detector()(); err == nil && info != nil {
+		switch info.Family {
+		case distro.FamilyDebian:
+			return backendUFW, nil
+		case distro.FamilyRHEL:
+			return backendFirewalld, nil
+		}
+	}
+
+	has := m.binaryExists()
+	switch {
+	case has("ufw"):
+		return backendUFW, nil
+	case has("firewall-cmd"):
+		return backendFirewalld, nil
+	case has("nft"):
+		return backendNftables, nil
+	default:
+		return "", fmt.Errorf("firewall: no supported backend detected")
+	}
+}
+
+func (m *Module) auditBackend(ctx context.Context, b backend) (auditState, error) {
+	switch b {
+	case backendUFW:
+		return m.auditUFW(ctx)
+	case backendFirewalld:
+		return m.auditFirewalld(ctx)
+	case backendNftables:
+		return m.auditNftables(ctx)
+	default:
+		return auditState{}, fmt.Errorf("firewall: unsupported backend %q", b)
+	}
+}
+
+func (m *Module) auditUFW(ctx context.Context) (auditState, error) {
+	out, err := m.runner()(ctx, "ufw", "status", "verbose")
+	if err != nil && strings.TrimSpace(out) == "" {
+		return auditState{}, fmt.Errorf("firewall: ufw status verbose: %w", err)
+	}
+	lower := strings.ToLower(out)
+	inbound, outbound := parseUFWDefaults(lower)
+	permissive := ufwHasSensitiveAny(lower)
+
+	return auditState{
+		backend:         backendUFW,
+		serviceKnown:    true,
+		serviceActive:   strings.Contains(lower, "status: active"),
+		serviceDetail:   strings.TrimSpace(firstLine(out)),
+		inboundKnown:    inbound != "",
+		inboundDrop:     inbound == "deny" || inbound == "drop" || inbound == "reject",
+		inboundValue:    inbound,
+		outboundKnown:   outbound != "",
+		outboundOK:      outbound == "allow" || outbound == "accept" || outbound == "deny" || outbound == "drop",
+		outboundValue:   outbound,
+		loopbackKnown:   true,
+		loopbackAllowed: ufwHasLoopbackRule(lower),
+		loopbackValue:   "parsed ufw status",
+		permissiveKnown: true,
+		permissiveFound: permissive,
+		permissiveValue: ufwSensitiveEvidence(lower),
+		ipv6RulesKnown:  true,
+		ipv6RulesFound:  strings.Contains(lower, "(v6)"),
+		ipv6Value:       "looked for (v6) rules",
+	}, nil
+}
+
+func (m *Module) auditFirewalld(ctx context.Context) (auditState, error) {
+	stateOut, stateErr := m.runner()(ctx, "firewall-cmd", "--state")
+	listOut, listErr := m.runner()(ctx, "firewall-cmd", "--list-all")
+	if stateErr != nil && listErr != nil {
+		return auditState{}, fmt.Errorf("firewall: firewalld unavailable")
+	}
+
+	target := parseFirewalldTarget(listOut)
+	permissive := firewalldHasSensitivePorts(listOut)
+	loopback := firewalldHasLoopback(listOut)
+
+	return auditState{
+		backend:         backendFirewalld,
+		serviceKnown:    true,
+		serviceActive:   strings.Contains(strings.ToLower(stateOut), "running"),
+		serviceDetail:   strings.TrimSpace(stateOut),
+		inboundKnown:    target != "",
+		inboundDrop:     target == "drop",
+		inboundValue:    target,
+		outboundKnown:   false,
+		outboundOK:      false,
+		outboundValue:   "zone model",
+		loopbackKnown:   true,
+		loopbackAllowed: loopback,
+		loopbackValue:   "checked interfaces/rules for lo",
+		permissiveKnown: true,
+		permissiveFound: permissive,
+		permissiveValue: firewalldSensitiveEvidence(listOut),
+		ipv6RulesKnown:  true,
+		ipv6RulesFound:  true,
+		ipv6Value:       "firewalld zones apply to IPv4 and IPv6",
+	}, nil
+}
+
+func (m *Module) auditNftables(ctx context.Context) (auditState, error) {
+	enabledOut, _ := m.runner()(ctx, "systemctl", "is-enabled", "nftables")
+	activeOut, _ := m.runner()(ctx, "systemctl", "is-active", "nftables")
+	rulesetOut, err := m.runner()(ctx, "nft", "list", "ruleset")
+	if err != nil && strings.TrimSpace(rulesetOut) == "" {
+		return auditState{}, fmt.Errorf("firewall: nft list ruleset: %w", err)
+	}
+
+	inbound := parseNftPolicy(rulesetOut, "input")
+	outbound := parseNftPolicy(rulesetOut, "output")
+	permissive := nftHasSensitiveAny(rulesetOut)
+
+	return auditState{
+		backend:         backendNftables,
+		serviceKnown:    true,
+		serviceActive:   strings.Contains(strings.ToLower(activeOut), "active") || strings.Contains(strings.ToLower(enabledOut), "enabled"),
+		serviceDetail:   strings.TrimSpace(activeOut),
+		inboundKnown:    inbound != "",
+		inboundDrop:     inbound == "drop",
+		inboundValue:    inbound,
+		outboundKnown:   outbound != "",
+		outboundOK:      outbound == "accept" || outbound == "drop",
+		outboundValue:   outbound,
+		loopbackKnown:   true,
+		loopbackAllowed: nftHasLoopbackRule(rulesetOut),
+		loopbackValue:   "looked for iif lo accept",
+		permissiveKnown: true,
+		permissiveFound: permissive,
+		permissiveValue: nftSensitiveEvidence(rulesetOut),
+		ipv6RulesKnown:  true,
+		ipv6RulesFound:  nftHasIPv6Rules(rulesetOut),
+		ipv6Value:       "checked ip6/inet tables",
+	}, nil
+}
+
+func (m *Module) findingService(s auditState) modules.Finding {
+	status := modules.StatusError
+	if s.serviceKnown {
+		status = boolStatus(s.serviceActive)
+	}
+	return modules.Finding{
+		Check:   checkFW001(),
+		Status:  status,
+		Current: fmt.Sprintf("backend=%s active=%t", s.backend, s.serviceActive),
+		Target:  "service enabled and active",
+		Detail:  s.serviceDetail,
+	}
+}
+
+func (m *Module) findingInbound(s auditState) modules.Finding {
+	if !s.inboundKnown {
+		return modules.Finding{Check: checkFW002(), Status: modules.StatusManual, Current: "unknown", Target: "DROP", Detail: "could not infer inbound default policy"}
+	}
+	return modules.Finding{Check: checkFW002(), Status: boolStatus(s.inboundDrop), Current: s.inboundValue, Target: "drop"}
+}
+
+func (m *Module) findingOutbound(s auditState) modules.Finding {
+	if !s.outboundKnown {
+		return modules.Finding{Check: checkFW003(), Status: modules.StatusSkipped, Current: s.outboundValue, Target: "drop or accept", Detail: "backend does not expose global outbound default in the same way"}
+	}
+	return modules.Finding{Check: checkFW003(), Status: boolStatus(s.outboundOK), Current: s.outboundValue, Target: "drop or accept"}
+}
+
+func (m *Module) findingLoopback(s auditState) modules.Finding {
+	if !s.loopbackKnown {
+		return modules.Finding{Check: checkFW004(), Status: modules.StatusManual, Current: "unknown", Target: "loopback explicitly allowed"}
+	}
+	return modules.Finding{Check: checkFW004(), Status: boolStatus(s.loopbackAllowed), Current: s.loopbackValue, Target: "loopback explicitly allowed"}
+}
+
+func (m *Module) findingPermissive(s auditState) modules.Finding {
+	if !s.permissiveKnown {
+		return modules.Finding{Check: checkFW005(), Status: modules.StatusManual, Current: "unknown", Target: "no global sensitive port exposure"}
+	}
+	return modules.Finding{Check: checkFW005(), Status: boolStatus(!s.permissiveFound), Current: s.permissiveValue, Target: "no sensitive ports open to any source"}
+}
+
+func (m *Module) findingIPv6(s auditState, ipv6Enabled bool) modules.Finding {
+	if !ipv6Enabled {
+		return modules.Finding{Check: checkFW006(), Status: modules.StatusSkipped, Current: "ipv6 disabled", Target: "rules present when enabled", Detail: "net.ipv6.conf.all.disable_ipv6=1"}
+	}
+	if !s.ipv6RulesKnown {
+		return modules.Finding{Check: checkFW006(), Status: modules.StatusManual, Current: "unknown", Target: "ipv6 rules present"}
+	}
+	return modules.Finding{Check: checkFW006(), Status: boolStatus(s.ipv6RulesFound), Current: s.ipv6Value, Target: "ipv6 rules present"}
+}
+
+func (m *Module) errorFindings(err error) []modules.Finding {
+	ids := []modules.Check{checkFW001(), checkFW002(), checkFW003(), checkFW004(), checkFW005(), checkFW006()}
+	out := make([]modules.Finding, 0, len(ids))
+	for _, chk := range ids {
+		out = append(out, modules.Finding{Check: chk, Status: modules.StatusError, Current: "unavailable", Target: "see check", Detail: err.Error()})
+	}
+	return out
+}
+
+func (m *Module) isIPv6Enabled() bool {
+	data, err := os.ReadFile(m.ipv6Path())
+	if err != nil {
+		return true
+	}
+	return strings.TrimSpace(string(data)) != "1"
+}
+
+func boolStatus(ok bool) modules.Status {
+	if ok {
+		return modules.StatusCompliant
+	}
+	return modules.StatusNonCompliant
+}
+
+func parseUFWDefaults(out string) (string, string) {
+	out = strings.ToLower(out)
+	re := regexp.MustCompile(`default:\s*([a-z]+)\s*\(incoming\),\s*([a-z]+)\s*\(outgoing\)`)
+	m := re.FindStringSubmatch(out)
+	if len(m) != 3 {
+		return "", ""
+	}
+	return strings.ToLower(m[1]), strings.ToLower(m[2])
+}
+
+func ufwHasLoopbackRule(out string) bool {
+	re := regexp.MustCompile(`(?m)(allow|accept).*\blo\b|\blo\b.*(allow|accept)`)
+	return re.MatchString(out)
+}
+
+func ufwHasSensitiveAny(out string) bool {
+	re := regexp.MustCompile(`(?m)\b(22|23|3389|3306|5432|6379|27017)(/(tcp|udp))?\b.*\b(allow|accept)\b.*\b(anywhere|0\.0\.0\.0/0)\b`)
+	return re.MatchString(out)
+}
+
+func ufwSensitiveEvidence(out string) string {
+	if !ufwHasSensitiveAny(out) {
+		return "no sensitive any-source rule found"
+	}
+	for _, line := range strings.Split(out, "\n") {
+		l := strings.ToLower(strings.TrimSpace(line))
+		if l == "" {
+			continue
+		}
+		if regexp.MustCompile(`\b(22|23|3389|3306|5432|6379|27017)(/(tcp|udp))?\b`).MatchString(l) && strings.Contains(l, "allow") && (strings.Contains(l, "anywhere") || strings.Contains(l, "0.0.0.0/0")) {
+			return line
+		}
+	}
+	return "sensitive any-source rule found"
+}
+
+func parseFirewalldTarget(out string) string {
+	re := regexp.MustCompile(`(?m)^\s*target:\s*(\S+)`)
+	m := re.FindStringSubmatch(strings.ToLower(out))
+	if len(m) != 2 {
+		return ""
+	}
+	return m[1]
+}
+
+func firewalldHasLoopback(out string) bool {
+	l := strings.ToLower(out)
+	if regexp.MustCompile(`(?m)^\s*interfaces:\s*.*\blo\b`).MatchString(l) {
+		return true
+	}
+	return strings.Contains(l, "127.0.0.1") || strings.Contains(l, "::1")
+}
+
+func firewalldHasSensitivePorts(out string) bool {
+	re := regexp.MustCompile(`(?m)^\s*ports:\s*(.*)$`)
+	m := re.FindStringSubmatch(strings.ToLower(out))
+	if len(m) != 2 {
+		return false
+	}
+	return regexp.MustCompile(`\b(22|23|3389|3306|5432|6379|27017)/(tcp|udp)\b`).MatchString(m[1])
+}
+
+func firewalldSensitiveEvidence(out string) string {
+	if !firewalldHasSensitivePorts(out) {
+		return "no sensitive ports line detected"
+	}
+	for _, line := range strings.Split(out, "\n") {
+		l := strings.ToLower(strings.TrimSpace(line))
+		if strings.HasPrefix(l, "ports:") {
+			return strings.TrimSpace(line)
+		}
+	}
+	return "sensitive ports exposed"
+}
+
+func parseNftPolicy(out, chain string) string {
+	re := regexp.MustCompile(fmt.Sprintf(`hook\s+%s\s+priority\s+\S+;\s+policy\s+(accept|drop);`, regexp.QuoteMeta(chain)))
+	m := re.FindStringSubmatch(strings.ToLower(out))
+	if len(m) != 2 {
+		return ""
+	}
+	return m[1]
+}
+
+func nftHasLoopbackRule(out string) bool {
+	l := strings.ToLower(out)
+	return regexp.MustCompile(`iif(name)?\s+"lo"\s+accept`).MatchString(l)
+}
+
+func nftHasSensitiveAny(out string) bool {
+	l := strings.ToLower(out)
+	if regexp.MustCompile(`tcp\s+dport\s+(22|23|3389|3306|5432|6379|27017)\s+accept`).MatchString(l) {
+		return true
+	}
+	return regexp.MustCompile(`(ip|ip6)\s+saddr\s+(0\.0\.0\.0/0|::/0).*tcp\s+dport\s+(22|23|3389|3306|5432|6379|27017).*accept`).MatchString(l)
+}
+
+func nftSensitiveEvidence(out string) string {
+	if !nftHasSensitiveAny(out) {
+		return "no sensitive permissive nft rule found"
+	}
+	for _, line := range strings.Split(out, "\n") {
+		l := strings.ToLower(strings.TrimSpace(line))
+		if l == "" {
+			continue
+		}
+		if regexp.MustCompile(`tcp\s+dport\s+(22|23|3389|3306|5432|6379|27017)\s+accept`).MatchString(l) {
+			return line
+		}
+	}
+	return "sensitive permissive nft rule found"
+}
+
+func nftHasIPv6Rules(out string) bool {
+	l := strings.ToLower(out)
+	return strings.Contains(l, "table ip6") || strings.Contains(l, "ip6 saddr") || strings.Contains(l, "nfproto ipv6")
+}
+
+func firstLine(s string) string {
+	for _, line := range strings.Split(s, "\n") {
+		if strings.TrimSpace(line) != "" {
+			return line
+		}
+	}
+	return ""
+}
+
+func runCommand(ctx context.Context, name string, args ...string) (string, error) {
+	cmd := exec.CommandContext(ctx, name, args...)
+	out, err := cmd.CombinedOutput()
+	result := strings.TrimSpace(string(out))
+	if err != nil {
+		if result == "" {
+			return "", fmt.Errorf("run %s %s: %w", name, strings.Join(args, " "), err)
+		}
+		return result, fmt.Errorf("run %s %s: %s", name, strings.Join(args, " "), result)
+	}
+	return result, nil
+}

--- a/internal/modules/firewall/module_test.go
+++ b/internal/modules/firewall/module_test.go
@@ -1,0 +1,215 @@
+package firewall_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/hardbox-io/hardbox/internal/distro"
+	"github.com/hardbox-io/hardbox/internal/modules"
+	"github.com/hardbox-io/hardbox/internal/modules/firewall"
+)
+
+func TestModule_ImplementsInterface(t *testing.T) {
+	var _ modules.Module = firewall.NewModuleForTest(nil, nil, nil, "", "")
+}
+
+func TestModule_NameAndVersion(t *testing.T) {
+	m := firewall.NewModuleForTest(nil, nil, nil, "", "")
+	if m.Name() != "firewall" {
+		t.Fatalf("Name(): got %q", m.Name())
+	}
+	if m.Version() == "" {
+		t.Fatal("Version() should not be empty")
+	}
+}
+
+func TestAudit_UFWCompliant(t *testing.T) {
+	ipv6 := writeIPv6DisableFile(t, "0\n")
+	m := firewall.NewModuleForTest(fakeRunner(map[string]fakeResult{
+		"ufw status verbose": {out: "Status: active\nDefault: deny (incoming), allow (outgoing), disabled (routed)\n22/tcp ALLOW 10.0.0.0/24\nAnywhere on lo ALLOW IN Anywhere\n22/tcp (v6) ALLOW ::/0\n"},
+	}), firewall.FakeDistroDebian, nil, "", ipv6)
+
+	findings, err := m.Audit(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("Audit(): %v", err)
+	}
+	if len(findings) != 6 {
+		t.Fatalf("expected 6 findings, got %d", len(findings))
+	}
+	assertStatus(t, findings, "fw-001", modules.StatusCompliant)
+	assertStatus(t, findings, "fw-002", modules.StatusCompliant)
+	assertStatus(t, findings, "fw-003", modules.StatusCompliant)
+	assertStatus(t, findings, "fw-004", modules.StatusCompliant)
+	assertStatus(t, findings, "fw-005", modules.StatusCompliant)
+	assertStatus(t, findings, "fw-006", modules.StatusCompliant)
+}
+
+func TestAudit_UFWSensitivePortOpen(t *testing.T) {
+	ipv6 := writeIPv6DisableFile(t, "0\n")
+	m := firewall.NewModuleForTest(fakeRunner(map[string]fakeResult{
+		"ufw status verbose": {out: "Status: active\nDefault: deny (incoming), allow (outgoing), disabled (routed)\n22/tcp ALLOW Anywhere\nAnywhere on lo ALLOW IN Anywhere\n"},
+	}), firewall.FakeDistroDebian, nil, "", ipv6)
+
+	findings, err := m.Audit(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("Audit(): %v", err)
+	}
+	assertStatus(t, findings, "fw-005", modules.StatusNonCompliant)
+	assertStatus(t, findings, "fw-006", modules.StatusNonCompliant)
+}
+
+func TestAudit_FirewalldInboundNotDrop(t *testing.T) {
+	ipv6 := writeIPv6DisableFile(t, "0\n")
+	m := firewall.NewModuleForTest(fakeRunner(map[string]fakeResult{
+		"firewall-cmd --state":    {out: "running"},
+		"firewall-cmd --list-all": {out: "public (active)\n  target: ACCEPT\n  interfaces: eth0 lo\n  ports: \n"},
+	}), firewall.FakeDistroRHEL, nil, "", ipv6)
+
+	findings, err := m.Audit(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("Audit(): %v", err)
+	}
+	assertStatus(t, findings, "fw-001", modules.StatusCompliant)
+	assertStatus(t, findings, "fw-002", modules.StatusNonCompliant)
+	assertStatus(t, findings, "fw-003", modules.StatusSkipped)
+	assertStatus(t, findings, "fw-004", modules.StatusCompliant)
+	assertStatus(t, findings, "fw-005", modules.StatusCompliant)
+	assertStatus(t, findings, "fw-006", modules.StatusCompliant)
+}
+
+func TestAudit_NftablesCompliant(t *testing.T) {
+	ipv6 := writeIPv6DisableFile(t, "0\n")
+	ruleset := `table inet filter {
+  chain input {
+    type filter hook input priority 0; policy drop;
+    iifname "lo" accept
+  }
+  chain output {
+    type filter hook output priority 0; policy accept;
+  }
+}
+table ip6 filter {
+  chain input {
+    type filter hook input priority 0; policy drop;
+  }
+}`
+	m := firewall.NewModuleForTest(fakeRunner(map[string]fakeResult{
+		"systemctl is-enabled nftables": {out: "enabled"},
+		"systemctl is-active nftables":  {out: "active"},
+		"nft list ruleset":              {out: ruleset},
+	}), nil, alwaysFalse, "nftables", ipv6)
+
+	findings, err := m.Audit(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("Audit(): %v", err)
+	}
+	for _, id := range []string{"fw-001", "fw-002", "fw-003", "fw-004", "fw-005", "fw-006"} {
+		assertStatus(t, findings, id, modules.StatusCompliant)
+	}
+}
+
+func TestAudit_IPv6DisabledSkipsFW006(t *testing.T) {
+	ipv6 := writeIPv6DisableFile(t, "1\n")
+	m := firewall.NewModuleForTest(fakeRunner(map[string]fakeResult{
+		"ufw status verbose": {out: "Status: active\nDefault: deny (incoming), allow (outgoing), disabled (routed)\nAnywhere on lo ALLOW IN Anywhere\n"},
+	}), firewall.FakeDistroDebian, nil, "", ipv6)
+
+	findings, err := m.Audit(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("Audit(): %v", err)
+	}
+	assertStatus(t, findings, "fw-006", modules.StatusSkipped)
+}
+
+func TestAudit_NoBackendDetectedReturnsErrors(t *testing.T) {
+	m := firewall.NewModuleForTest(nil, func() (*distro.Info, error) { return nil, fmt.Errorf("no distro") }, alwaysFalse, "", "")
+	findings, err := m.Audit(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("Audit(): %v", err)
+	}
+	if len(findings) != 6 {
+		t.Fatalf("expected 6 findings, got %d", len(findings))
+	}
+	for _, f := range findings {
+		if f.Status != modules.StatusError {
+			t.Fatalf("check %s should be error, got %s", f.Check.ID, f.Status)
+		}
+	}
+}
+
+func TestPlan_NoChanges(t *testing.T) {
+	m := firewall.NewModuleForTest(nil, firewall.FakeDistroDebian, alwaysTrue, "", "")
+	changes, err := m.Plan(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("Plan(): %v", err)
+	}
+	if len(changes) != 0 {
+		t.Fatalf("expected no changes, got %d", len(changes))
+	}
+}
+
+func TestParseUFWDefaults(t *testing.T) {
+	in, out := firewall.ParseUFWDefaults("Default: deny (incoming), allow (outgoing), disabled (routed)")
+	if in != "deny" || out != "allow" {
+		t.Fatalf("unexpected defaults: in=%q out=%q", in, out)
+	}
+}
+
+func TestNftHasIPv6Rules(t *testing.T) {
+	if !firewall.NftHasIPv6Rules("table ip6 filter {}") {
+		t.Fatal("expected ip6 table to be detected")
+	}
+	if firewall.NftHasIPv6Rules("table ip filter {}") {
+		t.Fatal("did not expect ipv6 rules")
+	}
+}
+
+func assertStatus(t *testing.T, findings []modules.Finding, id string, want modules.Status) {
+	t.Helper()
+	for _, f := range findings {
+		if f.Check.ID != id {
+			continue
+		}
+		if f.Status != want {
+			t.Fatalf("check %s: got %s want %s (current=%q detail=%q)", id, f.Status, want, f.Current, f.Detail)
+		}
+		return
+	}
+	t.Fatalf("check %s not found", id)
+}
+
+type fakeResult struct {
+	out string
+	err bool
+}
+
+func fakeRunner(results map[string]fakeResult) func(context.Context, string, ...string) (string, error) {
+	return func(_ context.Context, name string, args ...string) (string, error) {
+		key := strings.TrimSpace(name + " " + strings.Join(args, " "))
+		res, ok := results[key]
+		if !ok {
+			return "", fmt.Errorf("unexpected command: %s", key)
+		}
+		if res.err {
+			return res.out, fmt.Errorf("command failed: %s", key)
+		}
+		return res.out, nil
+	}
+}
+
+func writeIPv6DisableFile(t *testing.T, content string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "disable_ipv6")
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write ipv6 fixture: %v", err)
+	}
+	return path
+}
+
+func alwaysTrue(string) bool  { return true }
+func alwaysFalse(string) bool { return false }


### PR DESCRIPTION
## Summary
Implements issue #10 with a new firewall module supporting UFW, firewalld, and nftables auditing.

## What was added
- New package: internal/modules/firewall
- Checks: fw-001 to fw-006
- Backend selection:
  - Debian family -> UFW
  - RHEL family -> firewalld
  - Fallback by available binary (ufw, firewall-cmd, nft)
- Parsing implemented for:
  - ufw status verbose
  - firewall-cmd --state + firewall-cmd --list-all
  - nft list ruleset
- Registry integration in internal/engine/registry.go
- Compliance mappings updated in docs/COMPLIANCE.md
- Test suite for firewall module (11 tests)

## Validation
- go test ./internal/modules/firewall/... -v passed
- go build ./... passed

Closes #10