### PR TITLE
fix(engine): register SSH module in runtime registry

### DIFF
--- a/internal/engine/registry.go
+++ b/internal/engine/registry.go
@@ -6,6 +6,7 @@ import (
 	"github.com/hardbox-io/hardbox/internal/modules/containers"
 	"github.com/hardbox-io/hardbox/internal/modules/crypto"
 	"github.com/hardbox-io/hardbox/internal/modules/firewall"
+	"github.com/hardbox-io/hardbox/internal/modules/ssh"
 	"github.com/hardbox-io/hardbox/internal/modules/filesystem"
 	"github.com/hardbox-io/hardbox/internal/modules/kernel"
 	"github.com/hardbox-io/hardbox/internal/modules/logging"
@@ -36,8 +37,8 @@ func registeredModules() []modules.Module {
 		&firewall.Module{},
 		&crypto.Module{},
 		&containers.Module{},
+		&ssh.Module{},
 		// Stub placeholders — each will be fully implemented in its own package.
-		// &ssh.Module{},
 		// &pam.Module{},
 	}
 }

--- a/internal/engine/registry_test.go
+++ b/internal/engine/registry_test.go
@@ -1,0 +1,28 @@
+package engine
+
+import (
+	"testing"
+)
+
+// TestRegisteredModules_ContainsSSH verifies that the SSH module is present in
+// the built-in registry so that audit and apply flows include SSH checks.
+func TestRegisteredModules_ContainsSSH(t *testing.T) {
+	mods := registeredModules()
+	for _, m := range mods {
+		if m.Name() == "ssh" {
+			return
+		}
+	}
+	t.Fatal("ssh module is not registered in registeredModules(); add &ssh.Module{} to registry.go")
+}
+
+// TestRegisteredModules_NoDuplicates ensures no module name appears more than once.
+func TestRegisteredModules_NoDuplicates(t *testing.T) {
+	seen := make(map[string]bool)
+	for _, m := range registeredModules() {
+		if seen[m.Name()] {
+			t.Errorf("duplicate module name %q in registeredModules()", m.Name())
+		}
+		seen[m.Name()] = true
+	}
+}


### PR DESCRIPTION
## Summary

Closes #62.

The `ssh.Module` was fully implemented in `internal/modules/ssh` but was commented out in `registeredModules()`, causing `audit` and `apply` flows to silently skip all SSH hardening checks.

- Register `&ssh.Module{}` in `internal/engine/registry.go`
- Remove the stale comment placeholder
- Add `internal/engine/registry_test.go` with regression tests to prevent future silent removal

## Test plan

- [ ] `go test ./internal/engine/... -run TestRegisteredModules_ContainsSSH` passes
- [ ] `go test ./internal/engine/... -run TestRegisteredModules_NoDuplicates` passes
- [ ] Full suite `go test ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)