### PR TITLE
docs(readme): synchronize advertised profiles with shipped profile files

### DIFF
--- a/.github/workflows/profile-check.yaml
+++ b/.github/workflows/profile-check.yaml
@@ -1,0 +1,77 @@
+name: Profile Consistency Check
+permissions:
+  contents: read
+
+on:
+  push:
+    branches: [ main, develop ]
+    paths:
+      - "configs/profiles/**"
+      - "README.md"
+      - "docs/COMPLIANCE.md"
+      - "docs/ARCHITECTURE.md"
+  pull_request:
+    branches: [ main ]
+    paths:
+      - "configs/profiles/**"
+      - "README.md"
+      - "docs/COMPLIANCE.md"
+      - "docs/ARCHITECTURE.md"
+
+jobs:
+  check-profiles-vs-docs:
+    name: Verify shipped profiles are documented
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Collect shipped profile names
+        id: shipped
+        run: |
+          PROFILES=$(ls configs/profiles/*.yaml 2>/dev/null \
+            | xargs -I{} basename {} .yaml \
+            | sort \
+            | tr '\n' ' ')
+          echo "list=${PROFILES}" >> "$GITHUB_OUTPUT"
+          echo "Shipped profiles: ${PROFILES}"
+
+      - name: Assert every shipped profile appears in README
+        run: |
+          FAILED=0
+          for profile in ${{ steps.shipped.outputs.list }}; do
+            if ! grep -q "\`${profile}\`" README.md; then
+              echo "::error file=README.md::Shipped profile '${profile}' is not documented in README.md"
+              FAILED=1
+            else
+              echo "✓ ${profile} found in README.md"
+            fi
+          done
+          exit $FAILED
+
+      - name: Assert every shipped profile appears in COMPLIANCE.md
+        run: |
+          FAILED=0
+          for profile in ${{ steps.shipped.outputs.list }}; do
+            if ! grep -q "\`${profile}\`" docs/COMPLIANCE.md; then
+              echo "::error file=docs/COMPLIANCE.md::Shipped profile '${profile}' is not documented in docs/COMPLIANCE.md"
+              FAILED=1
+            else
+              echo "✓ ${profile} found in COMPLIANCE.md"
+            fi
+          done
+          exit $FAILED
+
+      - name: Warn about profiles listed in README that are not yet shipped
+        run: |
+          # Extract backtick-quoted identifiers from the README profiles table
+          DOCS_PROFILES=$(grep -oP '`[a-z][a-z0-9-]+`' README.md \
+            | tr -d '`' \
+            | grep -v '^hardbox$\|^cis$\|^json$\|^text$\|^markdown$\|^html$' \
+            | sort -u)
+
+          for doc_profile in ${DOCS_PROFILES}; do
+            if [ ! -f "configs/profiles/${doc_profile}.yaml" ]; then
+              echo "::notice file=README.md::Profile '${doc_profile}' is documented in README but not yet shipped (roadmap item)"
+            fi
+          done

--- a/README.md
+++ b/README.md
@@ -33,9 +33,9 @@ It covers every layer of the security stack: kernel parameters, SSH, firewall, P
 | Hardening is manual, slow, and inconsistent | Automated modules with dry-run and rollback |
 | Scripts break across distros | Distro-aware engine with a unified API |
 | No visibility into what was changed | Full audit trail + structured HTML/JSON reports |
-| Compliance frameworks are overwhelming | Built-in profiles: CIS L1/L2, STIG, PCI-DSS, HIPAA |
+| Compliance frameworks are overwhelming | Built-in profiles: CIS L1, production, dev (more on roadmap) |
 | Requires deep security expertise | Modern TUI — zero expertise needed to start |
-| Cloud environments have unique requirements | Cloud-native profiles for AWS, GCP, Azure, containers |
+| Cloud environments have unique requirements | Cloud-native profiles for AWS, GCP, Azure (roadmap) |
 
 ---
 
@@ -45,7 +45,7 @@ It covers every layer of the security stack: kernel parameters, SSH, firewall, P
 |:---|:---|
 | **Modern TUI** | Interactive terminal UI (Bubble Tea). Navigate, configure, and apply hardening without memorizing commands |
 | **Modular Architecture** | Enable or disable any module independently. Mix and match profiles at will |
-| **12 Built-in Profiles** | Production cloud, dev, CIS L1/L2, STIG, PCI-DSS, HIPAA, NIST, ISO 27001, AWS/GCP/Azure |
+| **3 Built-in Profiles** | `cis-level1`, `production`, `development` — more profiles on roadmap |
 | **Dry Run Mode** | Preview every exact change before it's applied. Safe to run on live servers |
 | **One-command Rollback** | Every change is snapshotted. Revert any module or an entire session instantly |
 | **Audit Reports** | JSON, HTML, and Markdown output — machine-readable and CI/CD-friendly |
@@ -122,22 +122,33 @@ sudo hardbox rollback --last
 
 ## Compliance Profiles
 
+### Available now
+
 <div align="center">
 
 | Profile | Framework | Best For |
 |:---:|:---|:---|
 | `cis-level1` | CIS Benchmarks Level 1 | Minimum baseline — low disruption |
-| `cis-level2` | CIS Benchmarks Level 2 | High-security, some service trade-offs |
-| `stig` | DoD STIG | Government / regulated environments |
-| `pci-dss` | PCI-DSS v4.0 | Cardholder data environments |
-| `hipaa` | HIPAA Security Rule | Healthcare systems |
-| `iso27001` | ISO/IEC 27001:2022 | Enterprise compliance |
-| `nist-800-53` | NIST SP 800-53 Rev. 5 | Federal / high-assurance |
 | `production` | hardbox curated | Cloud production servers |
 | `development` | hardbox curated | Dev/staging — security + developer usability |
-| `cloud-aws` | hardbox + CIS | AWS EC2 optimized |
-| `cloud-gcp` | hardbox + CIS | GCP Compute optimized |
-| `cloud-azure` | hardbox + CIS | Azure VM optimized |
+
+</div>
+
+### Roadmap — coming in future releases
+
+<div align="center">
+
+| Profile | Framework | Target Release |
+|:---:|:---|:---:|
+| `cis-level2` | CIS Benchmarks Level 2 | v0.2 |
+| `stig` | DoD STIG | v0.2 |
+| `pci-dss` | PCI-DSS v4.0 | v0.2 |
+| `hipaa` | HIPAA Security Rule | v0.3 |
+| `nist-800-53` | NIST SP 800-53 Rev. 5 | v0.3 |
+| `iso27001` | ISO/IEC 27001:2022 | v0.3 |
+| `cloud-aws` | hardbox + CIS | v0.3 |
+| `cloud-gcp` | hardbox + CIS | v0.3 |
+| `cloud-azure` | hardbox + CIS | v0.3 |
 
 </div>
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -97,19 +97,20 @@ hardbox/
 ├── configs/
 │   ├── hardbox.yaml                 # Default user config
 │   └── profiles/
-│       ├── base.yaml                # Shared base defaults
-│       ├── cis-level1.yaml
-│       ├── cis-level2.yaml
-│       ├── stig.yaml
-│       ├── pci-dss.yaml
-│       ├── hipaa.yaml
-│       ├── nist-800-53.yaml
-│       ├── iso27001.yaml
-│       ├── production.yaml
-│       ├── development.yaml
-│       ├── cloud-aws.yaml
-│       ├── cloud-gcp.yaml
-│       └── cloud-azure.yaml
+│       ├── cis-level1.yaml          # CIS Benchmarks Level 1 (shipped)
+│       ├── production.yaml          # hardbox curated — cloud production (shipped)
+│       ├── development.yaml         # hardbox curated — dev/staging (shipped)
+│       │
+│       │   # Roadmap — not yet shipped:
+│       ├── cis-level2.yaml          # (v0.2)
+│       ├── stig.yaml                # (v0.2)
+│       ├── pci-dss.yaml             # (v0.2)
+│       ├── hipaa.yaml               # (v0.3)
+│       ├── nist-800-53.yaml         # (v0.3)
+│       ├── iso27001.yaml            # (v0.3)
+│       ├── cloud-aws.yaml           # (v0.3)
+│       ├── cloud-gcp.yaml           # (v0.3)
+│       └── cloud-azure.yaml         # (v0.3)
 │
 ├── docs/
 │   ├── ARCHITECTURE.md              # This file

--- a/docs/COMPLIANCE.md
+++ b/docs/COMPLIANCE.md
@@ -245,34 +245,39 @@ This document is the authoritative cross-reference index.
 
 ## Profile → Framework Coverage Matrix
 
-This table shows which compliance frameworks each built-in profile satisfies.
+This table shows which compliance frameworks each **shipped** profile satisfies.
 
-| Profile | CIS L1 | CIS L2 | STIG | PCI-DSS | HIPAA | NIST 800-53 | ISO 27001 |
-|---|---|---|---|---|---|---|---|
-| `cis-level1` | ✓ Full | — | Partial | Partial | Partial | Partial | Partial |
-| `cis-level2` | ✓ Full | ✓ Full | Partial | Partial | Partial | Partial | Partial |
-| `stig` | ✓ Full | ✓ Full | ✓ Full | Partial | Partial | ✓ Full | Partial |
-| `pci-dss` | ✓ Full | ✓ Full | Partial | ✓ Full | Partial | Partial | Partial |
-| `hipaa` | ✓ Full | ✓ Full | Partial | Partial | ✓ Full | Partial | Partial |
-| `nist-800-53` | ✓ Full | ✓ Full | ✓ Full | Partial | Partial | ✓ Full | Partial |
-| `iso27001` | ✓ Full | ✓ Full | Partial | Partial | Partial | Partial | ✓ Full |
-| `production` | ✓ Full | Partial | Partial | Partial | Partial | Partial | Partial |
-| `development` | Partial | — | — | — | — | — | — |
+| Profile | CIS L1 | CIS L2 | STIG | PCI-DSS | HIPAA | NIST 800-53 | ISO 27001 | Status |
+|---|---|---|---|---|---|---|---|---|
+| `cis-level1` | ✓ Full | — | Partial | Partial | Partial | Partial | Partial | ✅ Shipped |
+| `production` | ✓ Full | Partial | Partial | Partial | Partial | Partial | Partial | ✅ Shipped |
+| `development` | Partial | — | — | — | — | — | — | ✅ Shipped |
+| `cis-level2` | ✓ Full | ✓ Full | Partial | Partial | Partial | Partial | Partial | 🗓 Roadmap v0.2 |
+| `stig` | ✓ Full | ✓ Full | ✓ Full | Partial | Partial | ✓ Full | Partial | 🗓 Roadmap v0.2 |
+| `pci-dss` | ✓ Full | ✓ Full | Partial | ✓ Full | Partial | Partial | Partial | 🗓 Roadmap v0.2 |
+| `hipaa` | ✓ Full | ✓ Full | Partial | Partial | ✓ Full | Partial | Partial | 🗓 Roadmap v0.3 |
+| `nist-800-53` | ✓ Full | ✓ Full | ✓ Full | Partial | Partial | ✓ Full | Partial | 🗓 Roadmap v0.3 |
+| `iso27001` | ✓ Full | ✓ Full | Partial | Partial | Partial | Partial | ✓ Full | 🗓 Roadmap v0.3 |
 
 > **Partial** = significant coverage with some controls requiring manual evidence or configuration beyond OS-level hardening (e.g., application-layer controls, physical security).
+> Roadmap profiles are not yet shipped — running them will return an error until the corresponding `.yaml` file is added to `configs/profiles/`.
 
 ---
 
 ## Generating a Compliance Report
 
 ```bash
-# Full compliance audit against PCI-DSS profile
-sudo hardbox audit --profile pci-dss --format html --output pci-audit.html
+# Full compliance audit against CIS Level 1
+sudo hardbox audit --profile cis-level1 --format html --output cis-audit.html
 
 # JSON output for SIEM/GRC tool import
-sudo hardbox audit --profile cis-level2 --format json --output cis-audit.json
+sudo hardbox audit --profile cis-level1 --format json --output cis-audit.json
 
 # Fail CI/CD pipeline if critical findings exist
 sudo hardbox audit --profile production --format json
 # exits 1 if audit.fail_on_critical = true and critical findings found
 ```
+
+> **Note:** The `pci-dss`, `cis-level2`, `stig`, and other compliance-specific profiles
+> are on the roadmap and will be available in future releases. Track progress in the
+> [v0.2 milestone](https://github.com/jackby03/hardbox/milestone/2).


### PR DESCRIPTION
## Summary

Closes #65.

README, ARCHITECTURE.md, and COMPLIANCE.md all listed 12 profiles that don't exist under `configs/profiles/`. Only 3 profiles are actually shipped: `cis-level1`, `production`, `development`. Users trying to use the documented profiles received a confusing runtime error.

### Changes

**README.md**
- Split **Compliance Profiles** table into two sections: *Available now* (3 profiles) and *Roadmap* (9 profiles with target release)
- Fixed pain-point row: "CIS L1/L2, STIG, PCI-DSS, HIPAA" → accurate statement
- Fixed Key Features count: ~~"12 Built-in Profiles"~~ → "3 Built-in Profiles — more on roadmap"

**docs/ARCHITECTURE.md**
- Annotated profile file tree: shipped profiles labeled, roadmap profiles annotated with target release

**docs/COMPLIANCE.md**
- Added `Status` column to coverage matrix (✅ Shipped / 🗓 Roadmap)
- Replaced broken CLI examples using `--profile pci-dss` / `--profile cis-level2` with working `--profile cis-level1` / `--profile production` examples
- Added note pointing to v0.2 milestone for roadmap profiles

**`.github/workflows/profile-check.yaml`** *(new)*
- Asserts every file in `configs/profiles/` is documented in README and COMPLIANCE.md (fails CI if a new profile ships without docs)
- Emits `:notice` annotations for roadmap profiles that are in docs but not yet shipped

## Test plan

- [x] All 3 shipped profiles (`cis-level1`, `production`, `development`) appear in README "Available now" table
- [x] All 9 roadmap profiles appear in README "Roadmap" table with target release
- [x] CLI examples in COMPLIANCE.md use only shipped profiles
- [x] ARCHITECTURE.md file tree accurately reflects `ls configs/profiles/`
- [x] CI workflow: `ls configs/profiles/*.yaml` and cross-reference with README/COMPLIANCE

🤖 Generated with [Claude Code](https://claude.com/claude-code)