### PR TITLE
fix(docs): fix broken CONTRIBUTING links in README and add link-check CI

### DIFF
--- a/.github/workflows/link-check.yaml
+++ b/.github/workflows/link-check.yaml
@@ -1,0 +1,53 @@
+name: Markdown Link Check
+permissions:
+  contents: read
+
+on:
+  push:
+    branches: [ main, develop ]
+    paths:
+      - "**.md"
+  pull_request:
+    branches: [ main ]
+    paths:
+      - "**.md"
+
+jobs:
+  link-check:
+    name: Check internal markdown links
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check internal file links in README.md
+        run: |
+          FAILED=0
+          LINKS=$(grep -oP '\]\(\K[^)]+' README.md | grep -v '^https\?://' | grep -v '^#')
+          for link in $LINKS; do
+            filepath="${link%%#*}"
+            [ -z "$filepath" ] && continue
+            if [ ! -e "$filepath" ]; then
+              echo "::error file=README.md::Broken link — '$filepath' does not exist"
+              FAILED=1
+            else
+              echo "✓ $filepath"
+            fi
+          done
+          exit $FAILED
+
+      - name: Check internal file links in CONTRIBUTING.md
+        run: |
+          FAILED=0
+          LINKS=$(grep -oP '\]\(\K[^)]+' CONTRIBUTING.md | grep -v '^https\?://' | grep -v '^#')
+          for link in $LINKS; do
+            filepath="${link%%#*}"
+            [ -z "$filepath" ] && continue
+            if [ ! -e "$filepath" ]; then
+              echo "::error file=CONTRIBUTING.md::Broken link — '$filepath' does not exist"
+              FAILED=1
+            else
+              echo "✓ $filepath"
+            fi
+          done
+          exit $FAILED

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![CIS Benchmarks](https://img.shields.io/badge/CIS-Level%201%20%26%202-2563EB?style=flat-square)](docs/COMPLIANCE.md)
 [![Build](https://img.shields.io/github/actions/workflow/status/jackby03/hardbox/ci.yaml?style=flat-square&label=CI)](https://github.com/jackby03/hardbox/actions)
 [![Platforms](https://img.shields.io/badge/platform-Ubuntu%20%7C%20Debian%20%7C%20RHEL%20%7C%20Rocky%20%7C%20Amazon%20Linux-475569?style=flat-square)]()
-[![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square)](docs/CONTRIBUTING.md)
+[![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square)](CONTRIBUTING.md)
 [![Code of Conduct](https://img.shields.io/badge/conduct-Contributor%20Covenant-5865F2?style=flat-square)](CODE_OF_CONDUCT.md)
 [![ACS compatible](https://img.shields.io/badge/ACS-compatible%20v1.0-4CAF50?style=flat-square)](https://acs.jackby03.com)
 
@@ -224,7 +224,7 @@ sudo go run ./cmd/hardbox
 ```
 
 Please read our [Code of Conduct](CODE_OF_CONDUCT.md) before contributing.  
-See [CONTRIBUTING.md](docs/CONTRIBUTING.md) for guidelines, module development guide, and test conventions.
+See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines, module development guide, and test conventions.
 
 ---
 


### PR DESCRIPTION
## Summary

Closes #68.

README had two links pointing to `docs/CONTRIBUTING.md` which does not exist — the actual file lives at the repository root (`CONTRIBUTING.md`). Contributors clicking the **PRs Welcome** badge or the inline link in the Contributing section were hitting a 404, creating immediate onboarding friction.

## Changes

| File | Change |
|---|---|
| `README.md` | Badge link: `docs/CONTRIBUTING.md` → `CONTRIBUTING.md` |
| `README.md` | Inline link: `docs/CONTRIBUTING.md` → `CONTRIBUTING.md` |
| `.github/workflows/link-check.yaml` *(new)* | CI job that scans `README.md` and `CONTRIBUTING.md` for relative file links and fails on any broken path |

## Test plan

- [x] Badge link (`[![PRs Welcome](...)](CONTRIBUTING.md)`) resolves correctly
- [x] Inline "See CONTRIBUTING.md" link in Contributing section resolves correctly
- [x] `link-check` CI job passes on this PR (both links now valid)
- [x] CI job would have caught the original broken link (`docs/CONTRIBUTING.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)