### PR TITLE
chore(ci): rename workflows for clarity

### DIFF
--- a/.agents/skills/github-flow/references/pr-workflow.md
+++ b/.agents/skills/github-flow/references/pr-workflow.md
@@ -127,7 +127,7 @@ hardbox uses **Squash and Merge** for all PRs:
 
 ## PR Title Validation
 
-PR titles are validated by CI (`.github/workflows/github-flow.yaml`).
+PR titles are validated by the contribution governance workflow (`.github/workflows/contribution-governance.yaml`).
 
 Valid format: `<type>(<scope>): <description>`
 

--- a/.github/workflows/contribution-governance.yaml
+++ b/.github/workflows/contribution-governance.yaml
@@ -1,4 +1,4 @@
-name: GitHub Flow
+name: Contribution Governance
 
 permissions:
   contents: read
@@ -174,7 +174,7 @@ jobs:
           RAW=$(awk '
             /Check branch naming convention/ {inblock=1; next}
             inblock && /PATTERN=/ {print; exit}
-          ' .github/workflows/github-flow.yaml)
+          ' .github/workflows/contribution-governance.yaml)
           TYPES=$(echo "$RAW" | sed -E "s/.*\^\(([^)]*)\).*/\1/" | tr '|' '\n' | sort -u)
           echo "types<<EOF" >> "$GITHUB_OUTPUT"
           echo "$TYPES" >> "$GITHUB_OUTPUT"
@@ -205,7 +205,7 @@ jobs:
 
           DIFF=$(diff <(echo "$WF") <(echo "$DOC") || true)
           if [ -n "$DIFF" ]; then
-            echo "::error file=AGENTS.md::Branch prefix drift detected between AGENTS.md and github-flow.yaml"
+            echo "::error file=AGENTS.md::Branch prefix drift detected between AGENTS.md and contribution-governance.yaml"
             echo "$DIFF"
             exit 1
           fi
@@ -217,7 +217,7 @@ jobs:
           RAW=$(awk '
             /Check PR title follows Conventional Commits/ {inblock=1; next}
             inblock && /PATTERN=/ {print; exit}
-          ' .github/workflows/github-flow.yaml)
+          ' .github/workflows/contribution-governance.yaml)
           TYPES=$(echo "$RAW" | sed -E "s/.*\^\(([^)]*)\).*/\1/" | tr '|' '\n' | sort -u)
           echo "types<<EOF" >> "$GITHUB_OUTPUT"
           echo "$TYPES" >> "$GITHUB_OUTPUT"
@@ -247,7 +247,7 @@ jobs:
 
           DIFF=$(diff <(echo "$WF") <(echo "$DOC") || true)
           if [ -n "$DIFF" ]; then
-            echo "::error file=AGENTS.md::PR title type drift detected between AGENTS.md and github-flow.yaml"
+            echo "::error file=AGENTS.md::PR title type drift detected between AGENTS.md and contribution-governance.yaml"
             echo "$DIFF"
             exit 1
           fi

--- a/.github/workflows/docs-publish.yaml
+++ b/.github/workflows/docs-publish.yaml
@@ -1,4 +1,4 @@
-name: Deploy GitHub Pages
+name: Documentation Publish
 permissions:
   contents: read
   pages: write

--- a/.github/workflows/quality-gates.yaml
+++ b/.github/workflows/quality-gates.yaml
@@ -1,4 +1,4 @@
-name: CI
+name: Quality Gates
 permissions:
   contents: read
 

--- a/.github/workflows/release-publish.yaml
+++ b/.github/workflows/release-publish.yaml
@@ -1,4 +1,4 @@
-name: Release
+name: Release Publish
 permissions:
   contents: write
 

--- a/.github/workflows/release-smoke.yaml
+++ b/.github/workflows/release-smoke.yaml
@@ -1,4 +1,4 @@
-name: Install Smoke Test
+name: Release Smoke
 permissions:
   contents: read
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,12 +90,13 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Added
-- `install-smoke.yaml` workflow to validate one-command installation on each published release.
+- `release-smoke.yaml` workflow to validate published release artifacts, installation, and minimal runtime behavior.
 
 ### Changed
 - `install.sh` now resolves release assets via GitHub API instead of hardcoded filenames, improving compatibility across release archive naming formats.
 - `install.sh` now returns explicit errors when a tag exists without a published GitHub Release or missing linux/checksum artifacts.
 - README Quick Start now uses the one-command installer and corrected rollback example (`hardbox rollback apply --last`).
+- Workflow files were renamed for clearer operational intent: `quality-gates.yaml`, `contribution-governance.yaml`, `release-publish.yaml`, `release-smoke.yaml`, and `docs-publish.yaml`.
 
 ### Planned for v0.2
 - `cis-level2`, `pci-dss`, `stig` compliance profiles

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg?style=flat-square)](LICENSE)
 [![Go Version](https://img.shields.io/badge/Go-1.22+-00ADD8?style=flat-square&logo=go&logoColor=white)](go.mod)
 [![CIS Benchmarks](https://img.shields.io/badge/CIS-Level%201-2563EB?style=flat-square)](docs/COMPLIANCE.md)
-[![Build](https://img.shields.io/github/actions/workflow/status/jackby03/hardbox/ci.yaml?style=flat-square&label=CI)](https://github.com/jackby03/hardbox/actions)
+[![Build](https://img.shields.io/github/actions/workflow/status/jackby03/hardbox/quality-gates.yaml?style=flat-square&label=quality)](https://github.com/jackby03/hardbox/actions)
 [![Platforms](https://img.shields.io/badge/platform-Ubuntu%20%7C%20Debian%20%7C%20RHEL%20%7C%20Rocky%20%7C%20Amazon%20Linux-475569?style=flat-square)]()
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square)](CONTRIBUTING.md)
 [![Code of Conduct](https://img.shields.io/badge/conduct-Contributor%20Covenant-5865F2?style=flat-square)](CODE_OF_CONDUCT.md)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -126,8 +126,11 @@ hardbox/
 │
 ├── .github/
 │   └── workflows/
-│       ├── ci.yaml                  # Build + test
-│       └── release.yaml             # GoReleaser on tag
+│       ├── quality-gates.yaml       # Build, lint, audit, repository checks
+│       ├── contribution-governance.yaml # Branch, PR, and policy rules
+│       ├── release-publish.yaml     # GoReleaser on version tags
+│       ├── release-smoke.yaml       # Post-release install and runtime smoke
+│       └── docs-publish.yaml        # GitHub Pages deploy
 │
 ├── go.mod
 ├── go.sum


### PR DESCRIPTION
## Summary
- rename workflow files to reflect their operational purpose
- update workflow display names for more professional check labels
- update references in README, architecture docs, changelog, and internal workflow guidance
- keep workflow behavior unchanged while improving naming consistency

## Renamed workflows
- ci.yaml -> quality-gates.yaml
- github-flow.yaml -> contribution-governance.yaml
- release.yaml -> release-publish.yaml
- install-smoke.yaml -> release-smoke.yaml
- pages.yaml -> docs-publish.yaml

## Validation
- workflow files and updated docs have no editor diagnostics
- active references were updated to the new names