### PR TITLE
test(ssh): skip file-mode assertion on Windows

### DIFF
--- a/internal/modules/ssh/module_test.go
+++ b/internal/modules/ssh/module_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -479,8 +480,13 @@ func assertConfigContains(t *testing.T, path, want string) {
 }
 
 // assertFileMode checks that the file at path has the expected permission bits.
+// On Windows, Unix permission bits are not enforced by the OS, so the check is skipped.
 func assertFileMode(t *testing.T, path string, want os.FileMode) {
 	t.Helper()
+	if runtime.GOOS == "windows" {
+		// Windows does not support Unix-style permission bits; skip the mode assertion.
+		return
+	}
 	info, err := os.Stat(path)
 	if err != nil {
 		t.Fatalf("stat %s: %v", path, err)


### PR DESCRIPTION
## Summary
- `assertFileMode` now skips the `0600` mode check on Windows since the OS does not enforce Unix permission bits
- Linux/Unix strict assertion (`0600`) is preserved unchanged
- `TestPlan_Apply_Revert` now passes on all supported dev platforms

## Test plan
- [x] `go test ./internal/modules/ssh/...` passes on Windows
- [x] No changes to Linux assertion logic — `runtime.GOOS != "windows"` path is identical to the original
- [x] Comment documents the platform-specific behavior

Closes #91

🤖 Generated with [Claude Code](https://claude.com/claude-code)