### PR TITLE
chore(v0.2): reconcile roadmap docs with shipped work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,11 +94,8 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - `cis-level2` compliance profile — CIS Benchmarks Level 2, high-security baseline for sensitive-data servers ([#84](https://github.com/jackby03/hardbox/issues/84))
 - `pci-dss` compliance profile — PCI-DSS v4.0, full cardholder data environment hardening with per-control requirement annotations ([#86](https://github.com/jackby03/hardbox/issues/86))
 - `stig` compliance profile — DISA STIG for Ubuntu 22.04 LTS V1R1, DoD-grade hardening with V-number annotations for every control ([#85](https://github.com/jackby03/hardbox/issues/85))
-
-### Added
 - `distro-parity` job matrix in `quality-gates.yaml` — builds, tests, and smoke-audits hardbox inside Rocky Linux 9 and RHEL UBI 9 containers on every PR ([#87](https://github.com/jackby03/hardbox/issues/87))
-- `Distro Parity Gate` summary job — single required check that blocks merge if any distro leg fails
-- `docs/DEVSECOPS.md` updated with distro parity scope, limitations, and instructions for adding new distros
+- `Distro Parity Gate` required check — blocks merge if any distro leg fails; `docs/DEVSECOPS.md` documents parity scope and how to add distros
 
 ### Changed
 - `install.sh` now resolves release assets via GitHub API instead of hardcoded filenames, improving compatibility across release archive naming formats.
@@ -109,7 +106,6 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Planned for v0.2
 - 14th module — mount and partition hardening
-- Full RHEL / Rocky Linux test parity
 
 ### Planned for v0.3
 - `hipaa`, `nist-800-53`, `iso27001` profiles

--- a/docs/COMPLIANCE.md
+++ b/docs/COMPLIANCE.md
@@ -287,6 +287,6 @@ sudo hardbox audit --profile cis-level2 --format json
 # exits 1 if audit.fail_on_critical or audit.fail_on_high = true and findings exist
 ```
 
-> **Note:** The `stig` and other compliance-specific profiles are on the roadmap
-> and will be available in future releases. Track progress in the
-> [v0.2 milestone](https://github.com/jackby03/hardbox/milestone/2).
+> **Note:** The `hipaa`, `nist-800-53`, `iso27001`, and other compliance-specific profiles
+> are on the roadmap and will be available in future releases. Track progress in the
+> [v0.3 milestone](https://github.com/jackby03/hardbox/milestone/3).


### PR DESCRIPTION
## Summary

Cleans up documentation drift accumulated during the v0.2 sprint.

### CHANGELOG.md
- Merges two duplicate `### Added` sections into one cohesive block
- Removes "Full RHEL / Rocky Linux test parity" from `Planned for v0.2` — it shipped in PR #100

### docs/COMPLIANCE.md
- Removes stale note listing `stig` as a roadmap profile — it shipped in PR #99
- Updates milestone link from v0.2 → v0.3 for the remaining `hipaa`/`nist-800-53`/`iso27001` profiles

## v0.2 status after this PR

| Item | Status |
|---|---|
| All P0 issues (#84 #85 #86 #87) | ✅ Shipped |
| CHANGELOG accurate | ✅ |
| README roadmap accurate | ✅ |
| COMPLIANCE.md accurate | ✅ |
| Mount hardening (#88) | ⏳ remaining |
| ARCHITECTURE.md (#90) | ⏳ remaining |

Closes #89 · Refs #93

🤖 Generated with [Claude Code](https://claude.ai/claude-code)