### PR TITLE
chore(v0.2): close mount-hardening gap and align ARCHITECTURE.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,7 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - `stig` compliance profile — DISA STIG for Ubuntu 22.04 LTS V1R1, DoD-grade hardening with V-number annotations for every control ([#85](https://github.com/jackby03/hardbox/issues/85))
 - `distro-parity` job matrix in `quality-gates.yaml` — builds, tests, and smoke-audits hardbox inside Rocky Linux 9 and RHEL UBI 9 containers on every PR ([#87](https://github.com/jackby03/hardbox/issues/87))
 - `Distro Parity Gate` required check — blocks merge if any distro leg fails; `docs/DEVSECOPS.md` documents parity scope and how to add distros
+- Filesystem module check `fs-008` — `/var/tmp` must be mounted `nodev,nosuid,noexec` (CIS 1.1.8–1.1.10, STIG V-238149); this control was present in all compliance profiles but absent from the audit check list ([#88](https://github.com/jackby03/hardbox/issues/88))
 
 ### Changed
 - `install.sh` now resolves release assets via GitHub API instead of hardcoded filenames, improving compatibility across release archive naming formats.

--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ sudo hardbox rollback apply --last
 - [x] `cis-level2` profile
 - [x] `pci-dss` profile
 - [x] `stig` profile
-- [ ] 14th module — mount hardening
+- [x] Filesystem — `/var/tmp` mount hardening check (fs-008, CIS 1.1.8–1.1.10)
 - [x] Full RHEL / Rocky Linux parity
 
 ### v0.3 — Ecosystem

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -23,36 +23,31 @@ hardbox/
 │
 ├── cmd/
 │   └── hardbox/
-│       └── main.go                  # Entry point — TUI or CLI dispatch
+│       └── main.go                  # Entry point — CLI dispatch and TUI launch
 │
 ├── internal/
 │   │
 │   ├── tui/                         # Terminal UI (Bubble Tea)
 │   │   ├── app.go                   # Root model, screen router
 │   │   ├── dashboard.go             # Main dashboard screen
-│   │   ├── module_list.go           # Module navigator/selector
-│   │   ├── module_detail.go         # Per-module config + preview
-│   │   ├── audit_view.go            # Audit results viewer
-│   │   ├── profile_picker.go        # Profile selection screen
-│   │   ├── confirm.go               # Apply confirmation dialog
-│   │   ├── progress.go              # Apply progress screen
-│   │   └── styles.go                # Centralised Lip Gloss styles
+│   │   ├── modules.go               # Module navigator/selector
+│   │   ├── moduledetail.go          # Per-module finding detail view
+│   │   └── workflow.go              # Apply / audit workflow screens
 │   │
 │   ├── engine/                      # Core hardening engine
 │   │   ├── engine.go                # Plan, Apply, Rollback orchestration
-│   │   ├── plan.go                  # Builds ordered change plan
-│   │   ├── executor.go              # Executes planned changes
-│   │   ├── snapshot.go              # Pre-apply system snapshot
-│   │   └── rollback.go              # Restores from snapshot
+│   │   ├── registry.go              # Module registry — all modules registered here
+│   │   └── snapshot.go              # Pre-apply system snapshot and rollback
 │   │
 │   ├── modules/                     # Individual hardening modules
-│   │   ├── module.go                # Module interface definition
+│   │   ├── module.go                # Module interface, Finding, Change, Check types
+│   │   ├── util/
+│   │   │   └── atomicwrite.go       # Atomic file write helper
 │   │   ├── ssh/
 │   │   ├── firewall/
 │   │   ├── kernel/
-│   │   ├── users/
-│   │   ├── pam/
-│   │   ├── filesystem/
+│   │   ├── users/                   # Users, PAM, password policy, sudo
+│   │   ├── filesystem/              # Mount options, file permissions, kernel modules
 │   │   ├── auditd/
 │   │   ├── services/
 │   │   ├── network/
@@ -63,48 +58,29 @@ hardbox/
 │   │   ├── updates/
 │   │   └── containers/
 │   │
-│   ├── audit/                       # Audit & reporting
-│   │   ├── auditor.go               # Runs checks without applying
-│   │   ├── finding.go               # Finding / result data model
-│   │   ├── report.go                # Report aggregation
-│   │   └── renderers/
-│   │       ├── json.go
-│   │       ├── html.go
-│   │       └── markdown.go
+│   ├── report/                      # Report generation
+│   │   ├── report.go                # Report aggregation and session model
+│   │   ├── render_json.go
+│   │   ├── render_html.go
+│   │   ├── render_markdown.go
+│   │   └── render_text.go
 │   │
-│   ├── distro/                      # Distro detection & abstraction
-│   │   ├── detect.go                # OS/version detection
-│   │   ├── apt.go                   # Debian/Ubuntu package ops
-│   │   ├── dnf.go                   # RHEL/Rocky/Fedora package ops
-│   │   └── service.go               # systemd service management
+│   ├── distro/                      # Distro detection and abstraction
+│   │   └── distro.go                # OS/version detection (Ubuntu, Debian, RHEL, Rocky…)
 │   │
-│   ├── config/                      # Config loading & validation
-│   │   ├── config.go                # Root config struct
-│   │   ├── loader.go                # Viper-based file + env loading
-│   │   └── validator.go             # Config schema validation
-│   │
-│   └── compliance/                  # Compliance framework mapping
-│       ├── frameworks.go            # CIS, NIST, PCI, HIPAA, STIG refs
-│       └── mapper.go                # Maps check IDs to controls
-│
-├── pkg/
-│   └── sysutil/                     # Safe system utilities
-│       ├── file.go                  # Atomic file writes
-│       ├── sysctl.go                # sysctl read/write
-│       ├── exec.go                  # Command execution wrapper
-│       └── privilege.go             # UID/privilege checks
+│   └── config/                      # Config loading
+│       └── config.go                # Root config struct and Viper-based loader
 │
 ├── configs/
-│   ├── hardbox.yaml                 # Default user config
-│   └── profiles/
+│   └── profiles/                    # Hardening profiles
 │       ├── cis-level1.yaml          # CIS Benchmarks Level 1 (shipped)
+│       ├── cis-level2.yaml          # CIS Benchmarks Level 2 (shipped)
+│       ├── pci-dss.yaml             # PCI-DSS v4.0 (shipped)
+│       ├── stig.yaml                # DISA STIG Ubuntu 22.04 V1R1 (shipped)
 │       ├── production.yaml          # hardbox curated — cloud production (shipped)
 │       ├── development.yaml         # hardbox curated — dev/staging (shipped)
 │       │
 │       │   # Roadmap — not yet shipped:
-│       ├── cis-level2.yaml          # (v0.2)
-│       ├── stig.yaml                # (v0.2)
-│       ├── pci-dss.yaml             # (v0.2)
 │       ├── hipaa.yaml               # (v0.3)
 │       ├── nist-800-53.yaml         # (v0.3)
 │       ├── iso27001.yaml            # (v0.3)
@@ -114,20 +90,14 @@ hardbox/
 │
 ├── docs/
 │   ├── ARCHITECTURE.md              # This file
-│   ├── MODULES.md                   # Module reference
 │   ├── COMPLIANCE.md                # Compliance mapping tables
-│   ├── PROFILES.md                  # Profile documentation
-│   ├── CONTRIBUTING.md              # Contribution guide
-│   └── PLUGIN_SDK.md                # Custom module development
-│
-├── scripts/
-│   ├── install.sh                   # One-liner installer
-│   └── test-distros.sh              # Multi-distro test runner
+│   ├── DEVSECOPS.md                 # CI/CD, release process, distro parity
+│   ├── MODULES.md                   # Module reference
+│   └── install.sh                   # One-liner installer (served at hardbox.jackby03.com)
 │
 ├── .github/
 │   └── workflows/
-│       ├── quality-gates.yaml       # Build, lint, audit, repository checks
-│       ├── contribution-governance.yaml # Branch, PR, and policy rules
+│       ├── quality-gates.yaml       # Build, test, lint, distro parity, repo checks
 │       ├── release-publish.yaml     # GoReleaser on version tags
 │       ├── release-smoke.yaml       # Post-release install and runtime smoke
 │       └── docs-publish.yaml        # GitHub Pages deploy
@@ -136,6 +106,11 @@ hardbox/
 ├── go.sum
 ├── Makefile
 ├── README.md
+├── CHANGELOG.md
+├── CONTRIBUTING.md
+├── SECURITY.md
+├── CODE_OF_CONDUCT.md
+├── AGENTS.md
 └── LICENSE
 ```
 

--- a/internal/modules/filesystem/checks.go
+++ b/internal/modules/filesystem/checks.go
@@ -132,6 +132,24 @@ func mountChecks() []mountCheckSpec {
 				},
 			},
 		},
+		{
+			mountPoint: "/var/tmp",
+			required:   []string{"nodev", "nosuid", "noexec"},
+			check: modules.Check{
+				ID:          "fs-008",
+				Title:       "Mount /var/tmp with nodev,nosuid,noexec",
+				Description: "/var/tmp is world-writable and persists across reboots; it must be mounted with nodev, nosuid, and noexec to prevent privilege escalation via SUID binaries or device files.",
+				Remediation: "Add nodev,nosuid,noexec to the /var/tmp entry in /etc/fstab and run: mount -o remount /var/tmp",
+				Severity:    modules.SeverityHigh,
+				Compliance: []modules.ComplianceRef{
+					{Framework: "CIS", Control: "1.1.8"},
+					{Framework: "CIS", Control: "1.1.9"},
+					{Framework: "CIS", Control: "1.1.10"},
+					{Framework: "NIST", Control: "CM-7"},
+					{Framework: "STIG", Control: "V-238149"},
+				},
+			},
+		},
 	}
 }
 


### PR DESCRIPTION
## Summary

Two remaining v0.2 issues resolved in one PR.

---

### #88 — Filesystem mount-hardening gap

**Gap analysis:** `/var/tmp` was configured in all compliance profiles (`cis-level2`, `pci-dss`, `stig`) with `var_tmp_nosuid/nodev/noexec: true`, but `mountChecks()` in `internal/modules/filesystem/checks.go` had no `fs-008` entry for it. The module was silently skipping this control.

**Fix:** Add `fs-008` — `/var/tmp nodev,nosuid,noexec` (CIS 1.1.8–1.1.10, STIG V-238149).

**Deferred (out of scope for v0.2):**
- Kernel module blacklisting (cramfs, squashfs, etc.) — profile flags exist, enforcement is in kernel module scope
- `/var/tmp` → `/tmp` bind mount detection — OS-specific, low ROI for a cross-distro tool

---

### #90 — ARCHITECTURE.md alignment

**Before → After for the repository tree:**

| Section | Was | Now |
|---|---|---|
| `tui/` | 9 files (7 fictional) | 5 real files |
| `engine/` | 5 files (3 fictional, missing `registry.go`) | 3 real files |
| `modules/` | includes fictional `pam/` | removed; `util/atomicwrite.go` added |
| `audit/` | fictional package with wrong paths | replaced by real `report/` package |
| `distro/` | 4 fictional files | 1 real file (`distro.go`) |
| `config/` | 3 fictional files | 1 real file (`config.go`) |
| `pkg/sysutil/` | listed (doesn't exist) | removed |
| `internal/compliance/` | listed (doesn't exist) | removed |
| `scripts/` | listed (doesn't exist) | removed |
| `contribution-governance.yaml` | listed | removed (deleted in PR #96) |
| `configs/profiles/` | cis-level2/pci-dss/stig as roadmap | all 6 marked as shipped |
| `docs/` | PROFILES.md, CONTRIBUTING.md, PLUGIN_SDK.md | replaced with real files |
| Root | missing CHANGELOG, CONTRIBUTING, etc. | added all real root files |

Closes #88 · Closes #90 · Refs #93

🤖 Generated with [Claude Code](https://claude.ai/claude-code)