### PR TITLE
feat(v0.3): add ISO/IEC 27001:2022 compliance profile (#105)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,7 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - `Distro Parity Gate` required check — blocks merge if any distro leg fails; `docs/DEVSECOPS.md` documents parity scope and how to add distros
 - Filesystem module check `fs-008` — `/var/tmp` must be mounted `nodev,nosuid,noexec` (CIS 1.1.8–1.1.10, STIG V-238149); this control was present in all compliance profiles but absent from the audit check list ([#88](https://github.com/jackby03/hardbox/issues/88))
 - `hipaa` compliance profile — HIPAA Security Rule (45 CFR Part 164), full ePHI environment hardening with per-section annotations (§164.308/310/312); 6-year log retention per §164.316(b)(2)(i) ([#103](https://github.com/jackby03/hardbox/issues/103))
+- `iso27001` compliance profile — ISO/IEC 27001:2022, ISMS-aligned OS hardening with Annex A control annotations (A.5–A.8) covering access control, cryptography, logging, network security, and vulnerability management ([#105](https://github.com/jackby03/hardbox/issues/105))
 
 ### Changed
 - `install.sh` now resolves release assets via GitHub API instead of hardcoded filenames, improving compatibility across release archive naming formats.
@@ -110,7 +111,7 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - 14th module — mount and partition hardening
 
 ### Planned for v0.3
-- `nist-800-53`, `iso27001` profiles
+- `nist-800-53` profile
 - `cloud-aws`, `cloud-gcp`, `cloud-azure` profiles
 - Ansible role integration
 - Terraform provisioner

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ It covers every layer of the security stack: kernel parameters, SSH, firewall, P
 |:---|:---|
 | **Modern TUI** | Interactive terminal UI (Bubble Tea). Navigate, configure, and apply hardening without memorizing commands |
 | **Modular Architecture** | Enable or disable any module independently. Mix and match profiles at will |
-| **7 Built-in Profiles** | `cis-level1`, `cis-level2`, `pci-dss`, `stig`, `hipaa`, `production`, `development` — more on roadmap |
+| **8 Built-in Profiles** | `cis-level1`, `cis-level2`, `pci-dss`, `stig`, `hipaa`, `iso27001`, `production`, `development` — more on roadmap |
 | **Dry Run Mode** | Preview every exact change before it's applied. Safe to run on live servers |
 | **One-command Rollback** | Every change is snapshotted. Revert any module or an entire session instantly |
 | **Audit Reports** | JSON, HTML, and Markdown output — machine-readable and CI/CD-friendly |
@@ -144,6 +144,7 @@ sudo hardbox rollback apply --last
 | `pci-dss` | PCI-DSS v4.0 | Cardholder data environments (CDE) |
 | `stig` | DISA STIG (Ubuntu 22.04 V1R1) | DoD and high-assurance systems |
 | `hipaa` | HIPAA Security Rule (45 CFR Part 164) | Healthcare — ePHI environments |
+| `iso27001` | ISO/IEC 27001:2022 | ISMS-certified and compliant organisations |
 | `production` | hardbox curated | Cloud production servers |
 | `development` | hardbox curated | Dev/staging — security + developer usability |
 
@@ -156,7 +157,6 @@ sudo hardbox rollback apply --last
 | Profile | Framework | Target Release |
 |:---:|:---|:---:|
 | `nist-800-53` | NIST SP 800-53 Rev. 5 | v0.3 |
-| `iso27001` | ISO/IEC 27001:2022 | v0.3 |
 | `cloud-aws` | hardbox + CIS | v0.3 |
 | `cloud-gcp` | hardbox + CIS | v0.3 |
 | `cloud-azure` | hardbox + CIS | v0.3 |
@@ -219,7 +219,8 @@ sudo hardbox rollback apply --last
 
 ### v0.3 — Ecosystem
 - [x] `hipaa` profile
-- [ ] `nist-800-53`, `iso27001` profiles
+- [x] `iso27001` profile
+- [ ] `nist-800-53` profile
 - [ ] `cloud-aws`, `cloud-gcp`, `cloud-azure` profiles
 - [ ] Ansible role integration
 - [ ] Terraform provisioner

--- a/configs/profiles/iso27001.yaml
+++ b/configs/profiles/iso27001.yaml
@@ -1,0 +1,266 @@
+# ISO/IEC 27001:2022 Compliance Profile
+# Designed for organisations implementing an Information Security Management
+# System (ISMS) in accordance with ISO/IEC 27001:2022 and its Annex A controls.
+#
+# Reference: ISO/IEC 27001:2022 — Information security, cybersecurity and
+# privacy protection — Information security management systems — Requirements.
+# Annex A controls follow ISO/IEC 27002:2022.
+#
+# ISO 27001 is risk-based rather than prescriptive; the control values below
+# represent the minimum technical baseline required to demonstrate conformity
+# with the relevant Annex A controls. Additional organisational, people, and
+# physical controls (Annex A clauses 5, 6, 7) must be addressed via policy
+# and operational procedures outside the scope of this profile.
+#
+# All checks are annotated with the applicable ISO 27001:2022 Annex A control
+# identifier (e.g., A.8.5 for Secure authentication).
+#
+# Clause structure (ISO/IEC 27001:2022 Annex A):
+#   A.5  — Organisational controls (37 controls)
+#   A.6  — People controls (8 controls)
+#   A.7  — Physical controls (14 controls)
+#   A.8  — Technological controls (34 controls)
+
+version: "1"
+profile: iso27001
+environment: onprem
+
+modules:
+  ssh:
+    enabled: true
+    # A.8.5  — Secure authentication: implement strong authentication mechanisms
+    # A.8.15 — Logging: log access to systems processing sensitive information
+    # A.8.20 — Networks security: protect networks and supporting infrastructure
+    client_alive_interval: 900     # A.8.5: terminate idle sessions (15-minute timeout)
+    client_alive_count_max: 0      # disconnect immediately on interval expiry
+    login_grace_time: 60           # A.8.5: limit unauthenticated connection window
+    # A.8.5  — Secure authentication: individual accountability; no shared accounts
+    disable_root_login: true       # root is a shared account — violates individual accountability
+    disable_empty_passwords: true  # A.8.5: password must meet complexity requirements
+    # A.8.20 — Networks security: restrict unnecessary network exposure
+    disable_x11_forwarding: true   # X11 forwarding exposes display sessions unnecessarily
+    disable_hostbased_auth: true   # A.8.5: authenticate using individual credentials only
+    disable_ignore_rhosts: true    # A.8.5: no host-trust file based authentication
+    disable_tcp_forwarding: false  # evaluate per environment; set true if not required
+    disable_agent_forwarding: false
+    log_level: VERBOSE             # A.8.15: log all authentication and access events
+    max_auth_tries: 4              # A.8.5: limit failed authentication attempts
+    max_sessions: 10
+    # A.8.24 — Use of cryptography: use strong cryptographic algorithms
+    # A.8.20 — Networks security: encrypt data in transit
+    ciphers:
+      - aes128-ctr
+      - aes192-ctr
+      - aes256-ctr
+      - aes128-gcm@openssh.com
+      - aes256-gcm@openssh.com
+      - chacha20-poly1305@openssh.com
+    macs:
+      - hmac-sha2-256-etm@openssh.com
+      - hmac-sha2-512-etm@openssh.com
+    kex_algorithms:
+      - curve25519-sha256
+      - curve25519-sha256@libssh.org
+      - diffie-hellman-group14-sha256
+      - diffie-hellman-group16-sha512
+      - diffie-hellman-group18-sha512
+
+  firewall:
+    enabled: true
+    # A.8.20 — Networks security: segregate networks and control traffic
+    # A.8.21 — Security of network services: protect networks and services
+    # A.5.14 — Information transfer: protect information in transit
+    backend: auto                  # auto-detect: ufw | nftables | firewalld
+    default_inbound: drop          # A.8.20: deny-by-default inbound policy
+    default_outbound: drop         # A.8.20: restrict egress; prevent data exfiltration
+    log_dropped: true              # A.8.15: log dropped traffic for security monitoring
+    # Define only the ports required by your documented business processes.
+    # A.8.8  — Management of technical vulnerabilities: minimise attack surface.
+    # A.5.37 — Documented operating procedures: document network access rules.
+    # Example:
+    # allowed_ingress:
+    #   - port: 443
+    #     proto: tcp
+    #     comment: "HTTPS — A.8.20: encrypted management and application access"
+    #   - port: 22
+    #     proto: tcp
+    #     comment: "SSH — A.8.5: restrict to authorised administrator source IPs"
+
+  kernel:
+    enabled: true
+    # A.8.8  — Management of technical vulnerabilities: apply hardening measures
+    # A.8.9  — Configuration management: maintain secure configurations
+    # A.8.26 — Application security requirements: enforce OS-level security controls
+    # Kernel module enforces:
+    # - kernel.randomize_va_space = 2   (ASLR — A.8.26: memory protection)
+    # - kernel.kptr_restrict = 2        (A.8.9: restrict kernel pointer exposure)
+    # - kernel.dmesg_restrict = 1       (A.8.9: restrict kernel log to privileged users)
+    # - net.ipv4 source routing disabled (A.8.20: prevent routing attacks)
+    # - net.ipv4.conf.all.log_martians = 1 (A.8.15: log suspicious network packets)
+    # - fs.suid_dumpable = 0            (A.8.9: prevent SUID core dumps)
+
+  users:
+    enabled: true
+    # A.8.2  — Privileged access rights: limit and control privileged access
+    # A.8.5  — Secure authentication: enforce strong authentication for all users
+    # A.5.15 — Access control: implement access control policy
+    # A.5.16 — Identity management: manage identity lifecycle
+    # A.5.17 — Authentication information: control allocation of authentication secrets
+    password_max_days: 90          # A.5.17: enforce regular password changes
+    password_min_days: 1           # prevent immediate password recycling
+    password_warn_age: 14          # advance notification before expiry
+    password_min_length: 12        # A.5.17: minimum password length; 12+ is best practice
+    password_complexity: true      # A.5.17: enforce complexity requirements
+    password_history: 6            # A.5.17: prevent reuse of recent passwords
+    # A.8.5  — Secure authentication: lockout after repeated failures
+    lockout_attempts: 5            # lock account after 5 consecutive failures
+    lockout_duration: 1800         # 30-minute lockout (1800 seconds)
+    # A.5.16 — Identity management: disable accounts no longer required
+    inactive_account_lock_days: 30 # A.5.16: disable inactive accounts within 30 days
+    su_restricted: true            # A.8.2: restrict privilege escalation to authorised users
+    umask: "027"                   # A.8.9: restrict default file creation permissions
+
+  filesystem:
+    enabled: true
+    # A.8.9  — Configuration management: maintain secure system configurations
+    # A.8.3  — Information access restriction: restrict access to sensitive resources
+    # A.7.10 — Storage media: protect media containing sensitive information
+    tmp_nosuid: true               # A.8.9: prevent SUID abuse in temporary directories
+    tmp_nodev: true
+    tmp_noexec: true               # A.8.9: prevent code execution in /tmp
+    devshm_nosuid: true
+    devshm_nodev: true
+    devshm_noexec: true
+    var_nosuid: true
+    var_tmp_nosuid: true
+    var_tmp_nodev: true
+    var_tmp_noexec: true
+    home_nodev: true
+    # A.8.8  — Management of technical vulnerabilities: reduce attack surface
+    disable_cramfs: true           # disable unused filesystems
+    disable_freevxfs: true
+    disable_jffs2: true
+    disable_hfs: true
+    disable_hfsplus: true
+    disable_udf: true
+
+  auditd:
+    enabled: true
+    # A.8.15 — Logging: produce, protect, and analyse event logs
+    # A.8.16 — Monitoring activities: monitor and detect anomalous behaviour
+    # A.5.33 — Protection of records: protect records against loss and tampering
+    max_log_file_size: 32          # MB per log file
+    num_logs: 10                   # retain 10 rotated log files
+    action_on_space_left: email    # A.8.15: alert before audit trail is lost
+    space_left_mb: 100             # alert with 100 MB remaining
+    immutable: false               # set true for highest-assurance ISMS environments
+    # Required audit events per A.8.15 and A.8.16
+    audit_privileged_commands: true  # A.8.2: track all privileged access and changes
+    audit_file_access: true          # A.8.15: log unauthorised file access attempts
+    audit_user_events: true          # A.8.16: all login, logout and session events
+    audit_sudo_commands: true        # A.8.2: log all administrative and privileged actions
+    audit_network_changes: true      # A.8.16: track network configuration changes
+    audit_time_change: true          # A.5.33: detect clock tampering to protect audit trail
+
+  services:
+    enabled: true
+    # A.8.8  — Management of technical vulnerabilities: disable unnecessary services
+    # A.8.9  — Configuration management: minimise system attack surface
+    # A.8.21 — Security of network services: disable insecure protocols
+    disable:
+      - xinetd
+      - inetd
+      - avahi-daemon             # A.8.9: mDNS/zeroconf unnecessary in managed environments
+      - cups                     # A.8.9: printing services rarely required on servers
+      - dhcpd
+      - slapd
+      - nfs-server
+      - bind
+      - vsftpd
+      - httpd
+      - apache2
+      - nginx                    # A.8.9: disable unless required for documented purpose
+      - dovecot
+      - sendmail
+      - samba
+      - squid
+      - snmpd                    # A.8.21: SNMPv1/v2 transmit community strings in cleartext
+      - nis
+      - telnet                   # A.8.21: no cleartext authentication channels
+      - rsh-server               # A.8.21: no trust-based remote shell access
+      - tftp-server
+      - rsync
+
+  network:
+    enabled: true
+    # A.8.20 — Networks security: protect network infrastructure
+    # A.8.21 — Security of network services: secure network protocols
+    disable_ipv6: false            # set true if IPv6 is not required in your environment
+    disable_wireless: true         # A.7.7: clear desk; A.8.20: disable unused interfaces
+    disable_dccp: true             # A.8.20: disable uncommon protocols not needed
+    disable_sctp: true
+    disable_rds: true
+    disable_tipc: true
+
+  crypto:
+    enabled: true
+    # A.8.24 — Use of cryptography: use appropriate cryptographic controls
+    # A.8.20 — Networks security: encrypt sensitive information in transit
+    # A.5.14 — Information transfer: protect data during transfer
+    min_tls_version: "1.2"         # A.8.24: TLS 1.0 and 1.1 are deprecated
+    disable_weak_ciphers: true     # A.8.24: remove weak/broken cipher suites
+    disable_weak_hashes: true      # A.8.24: reject MD5 and SHA-1 for integrity checks
+
+  logging:
+    enabled: true
+    # A.8.15 — Logging: retain event logs for analysis and legal requirements
+    # A.5.33 — Protection of records: retain records for required periods
+    # A.5.34 — Privacy and protection of PII: protect personally identifiable information
+    log_retention_days: 365        # A.5.33: minimum 1 year; adjust to legal requirements
+    remote_log_host: ""            # recommended: forward to off-system SIEM for A.8.15
+    remote_log_protocol: tcp       # TCP for reliable log delivery
+
+  mac:
+    enabled: true
+    # A.8.2  — Privileged access rights: enforce least-privilege process isolation
+    # A.5.15 — Access control: implement mandatory access controls
+    # A.8.26 — Application security requirements: enforce process confinement
+    enforce: true
+    deny_unknown: false            # set true for highest-assurance ISMS environments
+
+  ntp:
+    enabled: true
+    # A.8.17 — Clock synchronisation: synchronise system clocks to authorised sources
+    # A.8.15 — Logging: accurate timestamps are essential for event correlation
+    backend: auto                  # auto: chrony | systemd-timesyncd
+    timezone: UTC
+    # A.8.17: configure at least two NTP sources for accuracy and redundancy.
+    # servers:
+    #   - 0.pool.ntp.org
+    #   - 1.pool.ntp.org
+
+  updates:
+    enabled: true
+    # A.8.8  — Management of technical vulnerabilities: apply security patches promptly
+    # A.8.9  — Configuration management: maintain up-to-date system software
+    unattended_security_upgrades: true
+    auto_reboot: false             # schedule reboots during approved change windows
+
+  containers:
+    enabled: false                 # enable if running containerised workloads
+    # A.8.26 — Application security requirements: secure container environments
+    # A.5.15 — Access control: isolate containerised workloads
+    # A.8.9  — Configuration management: enforce consistent container configurations
+    # When enabled, container module enforces Docker daemon hardening,
+    # seccomp default profiles, user namespace remapping, and namespace isolation.
+
+report:
+  format: html
+  output_dir: /var/lib/hardbox/reports
+  include_remediation: true
+  include_evidence: true           # A.5.33: document security measures and evidence
+
+audit:
+  fail_on_critical: true
+  fail_on_high: true               # ISMS risk: all high-severity findings require remediation
+  fail_on_medium: false            # review medium findings; remediate per ISMS risk assessment

--- a/docs/COMPLIANCE.md
+++ b/docs/COMPLIANCE.md
@@ -257,7 +257,7 @@ This table shows which compliance frameworks each **shipped** profile satisfies.
 | `pci-dss` | ✓ Full | ✓ Full | Partial | ✓ Full | Partial | Partial | Partial | ✅ Shipped |
 | `hipaa` | ✓ Full | ✓ Full | Partial | Partial | ✓ Full | Partial | Partial | ✅ Shipped |
 | `nist-800-53` | ✓ Full | ✓ Full | ✓ Full | Partial | Partial | ✓ Full | Partial | 🗓 Roadmap v0.3 |
-| `iso27001` | ✓ Full | ✓ Full | Partial | Partial | Partial | Partial | ✓ Full | 🗓 Roadmap v0.3 |
+| `iso27001` | ✓ Full | ✓ Full | Partial | Partial | Partial | Partial | ✓ Full | ✅ Shipped |
 
 > **Partial** = significant coverage with some controls requiring manual evidence or configuration beyond OS-level hardening (e.g., application-layer controls, physical security).
 > Roadmap profiles (`hipaa`, `nist-800-53`, `iso27001`, and later) are not yet shipped — running them will return an error until the corresponding `.yaml` file is added to `configs/profiles/`.
@@ -285,11 +285,14 @@ sudo hardbox audit --profile stig --format html --output stig-audit.html
 # HIPAA Security Rule audit — ePHI environments
 sudo hardbox audit --profile hipaa --format html --output hipaa-audit.html
 
+# ISO/IEC 27001:2022 audit — ISMS-aligned environments
+sudo hardbox audit --profile iso27001 --format html --output iso27001-audit.html
+
 # Fail CI/CD pipeline if critical or high findings exist
 sudo hardbox audit --profile cis-level2 --format json
 # exits 1 if audit.fail_on_critical or audit.fail_on_high = true and findings exist
 ```
 
-> **Note:** The `nist-800-53`, `iso27001`, and cloud profiles are on the roadmap and will
+> **Note:** The `nist-800-53` and cloud profiles are on the roadmap and will
 > be available in future releases. Track progress in the
 > [v0.3 milestone](https://github.com/jackby03/hardbox/milestone/3).


### PR DESCRIPTION
- Add configs/profiles/iso27001.yaml with full Annex A control annotations
  (A.5–A.8) covering SSH, firewall, kernel, users, filesystem, auditd,
  services, network, crypto, logging, MAC, NTP, updates, and containers
- Document iso27001 profile in docs/COMPLIANCE.md; mark as Shipped in
  coverage matrix; add audit command example
- Add iso27001 to README.md Available profiles table; increment count to 8;
  mark roadmap checklist item as complete
- Record addition in CHANGELOG.md [Unreleased] Added section

https://claude.ai/code/session_016UiLjmeSDKyMW1yvK4SVaQ