### PR TITLE
feat(v0.3): add Ansible role for hardbox deployment (#109)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,8 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - `cloud-azure` compliance profile — CIS Azure Foundations Benchmark v2.1, OS hardening for Azure VMs with Azure-specific annotations (NSG, Defender for Cloud, Azure Policy, Disk Encryption, AAD login); includes guidance for Defender for Cloud Secure Score validation ([#108](https://github.com/jackby03/hardbox/issues/108))
 - cloud-init user-data templates for AWS EC2, GCP Compute Engine, and Azure VMs — each template installs hardbox with checksum verification, applies the provider-matched compliance profile on first boot, uploads the HTML audit report to cloud-native object storage (S3 / GCS / Blob), and configures a daily systemd re-hardening timer ([#111](https://github.com/jackby03/hardbox/issues/111))
 - `docs/CLOUD-INIT.md` — usage guide covering quick-start commands, IAM/RBAC requirements, configuration reference, timer management, and troubleshooting for all three cloud-init templates
+- Ansible role (`ansible-role/hardbox/`) — Galaxy-compatible role wrapping the hardbox CLI; supports all profiles, audit-only mode, report fetching, rollback on failure, custom profile upload, and systemd re-hardening timer; includes Molecule integration tests for Ubuntu 22.04, Debian 12, and Rocky Linux 9 ([#109](https://github.com/jackby03/hardbox/issues/109))
+- `docs/ANSIBLE.md` — Ansible role documentation covering installation, variable reference, example playbooks, CI/CD integration, and Molecule test instructions
 
 ### Changed
 - `install.sh` now resolves release assets via GitHub API instead of hardcoded filenames, improving compatibility across release archive naming formats.
@@ -117,7 +119,6 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Planned for v0.3
 - `nist-800-53` profile
-- Ansible role integration
 - Terraform provisioner plugin
 - cloud-init support
 

--- a/ansible-role/hardbox/README.md
+++ b/ansible-role/hardbox/README.md
@@ -1,0 +1,109 @@
+# Ansible Role: hardbox
+
+[![Ansible Galaxy](https://img.shields.io/badge/galaxy-jackby03.hardbox-blue)](https://galaxy.ansible.com/jackby03/hardbox)
+[![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](../../LICENSE)
+
+Installs and runs [hardbox](https://github.com/jackby03/hardbox) — a Linux OS hardening tool with built-in compliance profiles.
+
+## Requirements
+
+- Ansible >= 2.14
+- Target hosts: Ubuntu 20.04/22.04, Debian 11/12, RHEL/Rocky/AlmaLinux 8/9
+- Become (sudo) access on target hosts
+
+## Role Variables
+
+See [`defaults/main.yml`](defaults/main.yml) for the full list with inline documentation.
+
+| Variable | Default | Description |
+|---|---|---|
+| `hardbox_version` | `"latest"` | Release tag or `"latest"` |
+| `hardbox_profile` | `"production"` | Compliance profile to apply |
+| `hardbox_apply` | `true` | Apply hardening (`true`) or audit-only (`false`) |
+| `hardbox_dry_run` | `false` | Dry-run mode — preview changes without applying |
+| `hardbox_report_format` | `"html"` | Report format: `html`, `json`, `text`, `markdown` |
+| `hardbox_report_dir` | `/var/lib/hardbox/reports` | Report directory on target host |
+| `hardbox_fetch_report` | `false` | Fetch report to Ansible controller |
+| `hardbox_fetch_report_dest` | `"{{ playbook_dir }}/hardbox-reports"` | Local report destination |
+| `hardbox_rollback_on_failure` | `true` | Roll back on apply failure |
+| `hardbox_timer_enabled` | `false` | Install systemd re-hardening timer |
+| `hardbox_timer_schedule` | `"daily"` | systemd OnCalendar schedule |
+| `hardbox_fail_on_critical` | `true` | Fail play on critical findings |
+| `hardbox_fail_on_high` | `true` | Fail play on high findings |
+
+## Example Playbooks
+
+### Minimal — apply CIS Level 1 baseline
+
+```yaml
+- hosts: all
+  become: true
+  roles:
+    - role: jackby03.hardbox
+      vars:
+        hardbox_profile: cis-level1
+```
+
+### Audit-only — check compliance without changing anything
+
+```yaml
+- hosts: production
+  become: true
+  roles:
+    - role: jackby03.hardbox
+      vars:
+        hardbox_profile: pci-dss
+        hardbox_apply: false
+        hardbox_fetch_report: true
+        hardbox_report_format: html
+```
+
+### Cloud AWS — harden and fetch report
+
+```yaml
+- hosts: aws_ec2
+  become: true
+  roles:
+    - role: jackby03.hardbox
+      vars:
+        hardbox_profile: cloud-aws
+        hardbox_report_format: json
+        hardbox_fetch_report: true
+        hardbox_timer_enabled: true
+        hardbox_timer_schedule: "daily"
+```
+
+### Pin version and use custom profile
+
+```yaml
+- hosts: all
+  become: true
+  roles:
+    - role: jackby03.hardbox
+      vars:
+        hardbox_version: "v0.3.0"
+        hardbox_custom_profile_src: files/my-profile.yaml
+        hardbox_fetch_report: true
+```
+
+## Galaxy Installation
+
+```bash
+ansible-galaxy role install jackby03.hardbox
+```
+
+Or add to `requirements.yml`:
+
+```yaml
+roles:
+  - name: jackby03.hardbox
+    version: ">=0.3.0"
+```
+
+```bash
+ansible-galaxy install -r requirements.yml
+```
+
+## License
+
+MIT — see [LICENSE](../../LICENSE).

--- a/ansible-role/hardbox/defaults/main.yml
+++ b/ansible-role/hardbox/defaults/main.yml
@@ -1,0 +1,76 @@
+---
+# -------------------------------------------------------------------------
+# hardbox Ansible role — default variables
+# Override any of these in host_vars, group_vars, or the playbook vars block.
+# -------------------------------------------------------------------------
+
+# --- Installation ---
+# hardbox release to install. Use "latest" to always fetch the newest release,
+# or pin to a specific tag (e.g. "v0.3.0") for reproducible deployments.
+hardbox_version: "latest"
+
+# Directory where the hardbox binary is installed.
+hardbox_install_dir: /usr/local/bin
+
+# Temporary directory used during download and checksum verification.
+hardbox_tmp_dir: /tmp
+
+# --- Profile ---
+# Compliance profile to apply. Any profile shipped in configs/profiles/ is valid.
+# Common values: cis-level1, cis-level2, pci-dss, stig, hipaa, iso27001,
+#                nist-800-53, cloud-aws, cloud-gcp, cloud-azure,
+#                production, development
+hardbox_profile: production
+
+# Path to a custom profile YAML to copy to the target host.
+# When set, this file is uploaded and --profile is pointed at it.
+# Leave empty ("") to use one of the built-in profiles.
+hardbox_custom_profile_src: ""
+
+# --- Run mode ---
+# Whether to actually apply hardening (true) or only run an audit (false).
+hardbox_apply: true
+
+# Pass --dry-run to hardbox — show what would change without applying.
+hardbox_dry_run: false
+
+# Pass --non-interactive so hardbox never prompts (required in Ansible).
+hardbox_non_interactive: true
+
+# --- Reporting ---
+# Report output format: html | json | text | markdown
+hardbox_report_format: html
+
+# Directory on the target host where reports are stored.
+hardbox_report_dir: /var/lib/hardbox/reports
+
+# Fetch the generated report back to the Ansible controller.
+hardbox_fetch_report: false
+
+# Local directory on the Ansible controller to store fetched reports.
+hardbox_fetch_report_dest: "{{ playbook_dir }}/hardbox-reports"
+
+# --- Audit thresholds ---
+# Fail the play if hardbox exits with critical/high findings.
+# Mirrors the audit.fail_on_* settings in the profile YAML.
+hardbox_fail_on_critical: true
+hardbox_fail_on_high: true
+hardbox_fail_on_medium: false
+
+# --- Rollback ---
+# Run `hardbox rollback apply --last` on failure (via rescue block).
+hardbox_rollback_on_failure: true
+
+# --- Periodic re-hardening (systemd timer) ---
+# Install a systemd timer that re-runs hardbox apply on a schedule.
+hardbox_timer_enabled: false
+
+# OnCalendar value for the systemd timer (systemd time syntax).
+hardbox_timer_schedule: "daily"
+
+# OnBootSec — delay after boot before the first run.
+hardbox_timer_on_boot_sec: "5min"
+
+# --- Upgrade ---
+# Re-install hardbox even if the binary is already present at the target version.
+hardbox_force_reinstall: false

--- a/ansible-role/hardbox/handlers/main.yml
+++ b/ansible-role/hardbox/handlers/main.yml
@@ -1,0 +1,17 @@
+---
+# hardbox Ansible role — handlers
+
+- name: Verify hardbox installation
+  ansible.builtin.command: "{{ _hardbox_bin }} version"
+  changed_when: false
+  become: true
+
+- name: Reload systemd daemon
+  ansible.builtin.systemd:
+    daemon_reload: true
+
+- name: Restart hardbox timer
+  ansible.builtin.systemd:
+    name: hardbox-harden.timer
+    state: restarted
+    enabled: true

--- a/ansible-role/hardbox/meta/main.yml
+++ b/ansible-role/hardbox/meta/main.yml
@@ -1,0 +1,36 @@
+---
+galaxy_info:
+  role_name: hardbox
+  author: jackby03
+  description: >
+    Ansible role to install, configure, and run hardbox — a Linux system
+    hardening tool with built-in compliance profiles (CIS, NIST, STIG,
+    PCI-DSS, HIPAA, ISO 27001, and cloud provider benchmarks).
+  license: MIT
+  min_ansible_version: "2.14"
+
+  platforms:
+    - name: Ubuntu
+      versions:
+        - jammy       # 22.04 LTS
+        - focal       # 20.04 LTS
+    - name: Debian
+      versions:
+        - bullseye    # 11
+        - bookworm    # 12
+    - name: EL
+      versions:
+        - "8"
+        - "9"
+
+  galaxy_tags:
+    - security
+    - hardening
+    - compliance
+    - cis
+    - nist
+    - stig
+    - pci
+    - hipaa
+
+dependencies: []

--- a/ansible-role/hardbox/molecule/default/converge.yml
+++ b/ansible-role/hardbox/molecule/default/converge.yml
@@ -1,0 +1,14 @@
+---
+- name: Converge
+  hosts: all
+  become: true
+
+  pre_tasks:
+    - name: Update apt cache (Debian/Ubuntu)
+      ansible.builtin.apt:
+        update_cache: true
+        cache_valid_time: 3600
+      when: ansible_os_family == "Debian"
+
+  roles:
+    - role: hardbox

--- a/ansible-role/hardbox/molecule/default/molecule.yml
+++ b/ansible-role/hardbox/molecule/default/molecule.yml
@@ -1,0 +1,57 @@
+---
+dependency:
+  name: galaxy
+
+driver:
+  name: docker
+
+platforms:
+  - name: hardbox-ubuntu-2204
+    image: geerlingguy/docker-ubuntu2204-ansible:latest
+    pre_build_image: true
+    privileged: true
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns_mode: host
+    command: /lib/systemd/systemd
+
+  - name: hardbox-debian-12
+    image: geerlingguy/docker-debian12-ansible:latest
+    pre_build_image: true
+    privileged: true
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns_mode: host
+    command: /lib/systemd/systemd
+
+  - name: hardbox-rockylinux-9
+    image: geerlingguy/docker-rockylinux9-ansible:latest
+    pre_build_image: true
+    privileged: true
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns_mode: host
+    command: /lib/systemd/systemd
+
+provisioner:
+  name: ansible
+  playbooks:
+    converge: converge.yml
+    verify: verify.yml
+  inventory:
+    group_vars:
+      all:
+        hardbox_profile: cis-level1
+        hardbox_apply: true
+        hardbox_dry_run: true         # use dry-run in CI to avoid kernel changes in containers
+        hardbox_fetch_report: false
+        hardbox_fail_on_critical: false  # containers lack some kernel features; relax thresholds
+        hardbox_fail_on_high: false
+
+verifier:
+  name: ansible
+
+lint: |
+  set -e
+  yamllint .
+  ansible-lint

--- a/ansible-role/hardbox/molecule/default/verify.yml
+++ b/ansible-role/hardbox/molecule/default/verify.yml
@@ -1,0 +1,53 @@
+---
+- name: Verify
+  hosts: all
+  become: true
+
+  tasks:
+    - name: Check hardbox binary is installed
+      ansible.builtin.stat:
+        path: /usr/local/bin/hardbox
+      register: _hardbox_bin_stat
+
+    - name: Assert hardbox binary exists and is executable
+      ansible.builtin.assert:
+        that:
+          - _hardbox_bin_stat.stat.exists
+          - _hardbox_bin_stat.stat.executable
+        fail_msg: "hardbox binary not found or not executable at /usr/local/bin/hardbox"
+
+    - name: Run hardbox version
+      ansible.builtin.command: /usr/local/bin/hardbox version
+      register: _hardbox_version_output
+      changed_when: false
+
+    - name: Assert hardbox version output is non-empty
+      ansible.builtin.assert:
+        that:
+          - _hardbox_version_output.rc == 0
+          - _hardbox_version_output.stdout | length > 0
+        fail_msg: "hardbox version command failed: {{ _hardbox_version_output.stderr }}"
+
+    - name: Check report directory exists
+      ansible.builtin.stat:
+        path: /var/lib/hardbox/reports
+      register: _hardbox_report_dir
+
+    - name: Assert report directory exists with correct permissions
+      ansible.builtin.assert:
+        that:
+          - _hardbox_report_dir.stat.exists
+          - _hardbox_report_dir.stat.isdir
+          - _hardbox_report_dir.stat.mode == "0750"
+        fail_msg: "Report directory /var/lib/hardbox/reports missing or has wrong permissions"
+
+    - name: Find generated report files
+      ansible.builtin.find:
+        paths: /var/lib/hardbox/reports
+        patterns: "hardbox-*.html"
+      register: _hardbox_reports
+
+    - name: Assert at least one report was generated
+      ansible.builtin.assert:
+        that: _hardbox_reports.matched >= 1
+        fail_msg: "No hardbox report files found in /var/lib/hardbox/reports"

--- a/ansible-role/hardbox/tasks/apply.yml
+++ b/ansible-role/hardbox/tasks/apply.yml
@@ -1,0 +1,70 @@
+---
+# hardbox apply — apply hardening profile with optional rollback on failure
+
+- name: Set profile argument
+  ansible.builtin.set_fact:
+    _hardbox_profile_arg: >-
+      {{
+        (hardbox_custom_profile_src | length > 0)
+        | ternary(_hardbox_custom_profile_dest, hardbox_profile)
+      }}
+
+- name: Set report file path
+  ansible.builtin.set_fact:
+    _hardbox_report_file: >-
+      {{ hardbox_report_dir }}/hardbox-{{ inventory_hostname }}-{{ ansible_date_time.iso8601_basic_short }}.{{ hardbox_report_format }}
+
+- name: Apply hardbox hardening profile
+  ansible.builtin.command:
+    cmd: >-
+      {{ _hardbox_bin }} apply
+      --profile {{ _hardbox_profile_arg }}
+      --format {{ hardbox_report_format }}
+      --output {{ _hardbox_report_file }}
+      {{ '--dry-run' if hardbox_dry_run | bool else '' }}
+      {{ '--non-interactive' if hardbox_non_interactive | bool else '' }}
+  register: _hardbox_apply_result
+  changed_when: "'Applied' in _hardbox_apply_result.stdout or _hardbox_apply_result.rc == 0"
+  failed_when: _hardbox_apply_result.rc not in [0, 1]
+  become: true
+  block: []
+  rescue:
+    - name: Run rollback on apply failure
+      ansible.builtin.command:
+        cmd: "{{ _hardbox_bin }} rollback apply --last"
+      when: hardbox_rollback_on_failure | bool
+      become: true
+      register: _hardbox_rollback_result
+
+    - name: Log rollback result
+      ansible.builtin.debug:
+        msg: "Rollback completed: {{ _hardbox_rollback_result.stdout }}"
+      when: hardbox_rollback_on_failure | bool
+
+    - name: Fail after rollback
+      ansible.builtin.fail:
+        msg: >
+          hardbox apply failed (rc={{ _hardbox_apply_result.rc }}).
+          Rollback has been applied. Review the output:
+          {{ _hardbox_apply_result.stderr }}
+
+- name: Display hardbox apply output
+  ansible.builtin.debug:
+    msg: "{{ _hardbox_apply_result.stdout_lines }}"
+  when: _hardbox_apply_result.stdout_lines is defined
+
+- name: Check for critical/high findings
+  ansible.builtin.fail:
+    msg: >
+      hardbox apply reported findings that exceed configured thresholds.
+      Review the report at {{ _hardbox_report_file }} on {{ inventory_hostname }}.
+  when:
+    - _hardbox_apply_result.rc == 1
+    - hardbox_fail_on_critical | bool or hardbox_fail_on_high | bool
+
+- name: Fetch report to Ansible controller
+  ansible.builtin.fetch:
+    src: "{{ _hardbox_report_file }}"
+    dest: "{{ hardbox_fetch_report_dest }}/{{ inventory_hostname }}/"
+    flat: true
+  when: hardbox_fetch_report | bool

--- a/ansible-role/hardbox/tasks/audit.yml
+++ b/ansible-role/hardbox/tasks/audit.yml
@@ -1,0 +1,49 @@
+---
+# hardbox audit — read-only compliance check, no changes applied
+
+- name: Set report file path
+  ansible.builtin.set_fact:
+    _hardbox_report_file: >-
+      {{ hardbox_report_dir }}/hardbox-audit-{{ inventory_hostname }}-{{ ansible_date_time.iso8601_basic_short }}.{{ hardbox_report_format }}
+
+- name: Set profile argument
+  ansible.builtin.set_fact:
+    _hardbox_profile_arg: >-
+      {{
+        (hardbox_custom_profile_src | length > 0)
+        | ternary(_hardbox_custom_profile_dest, hardbox_profile)
+      }}
+
+- name: Run hardbox audit (read-only)
+  ansible.builtin.command:
+    cmd: >-
+      {{ _hardbox_bin }} audit
+      --profile {{ _hardbox_profile_arg }}
+      --format {{ hardbox_report_format }}
+      --output {{ _hardbox_report_file }}
+      {{ '--non-interactive' if hardbox_non_interactive | bool else '' }}
+  register: _hardbox_audit_result
+  changed_when: false
+  failed_when: _hardbox_audit_result.rc not in [0, 1]
+  become: true
+
+- name: Display hardbox audit output
+  ansible.builtin.debug:
+    msg: "{{ _hardbox_audit_result.stdout_lines }}"
+  when: _hardbox_audit_result.stdout_lines is defined
+
+- name: Fail on critical/high findings
+  ansible.builtin.fail:
+    msg: >
+      hardbox audit found issues exceeding configured thresholds.
+      Review the report at {{ _hardbox_report_file }} on {{ inventory_hostname }}.
+  when:
+    - _hardbox_audit_result.rc == 1
+    - hardbox_fail_on_critical | bool or hardbox_fail_on_high | bool
+
+- name: Fetch audit report to Ansible controller
+  ansible.builtin.fetch:
+    src: "{{ _hardbox_report_file }}"
+    dest: "{{ hardbox_fetch_report_dest }}/{{ inventory_hostname }}/"
+    flat: true
+  when: hardbox_fetch_report | bool

--- a/ansible-role/hardbox/tasks/install.yml
+++ b/ansible-role/hardbox/tasks/install.yml
@@ -1,0 +1,139 @@
+---
+# hardbox installation with checksum verification
+
+- name: Check if hardbox is already installed
+  ansible.builtin.stat:
+    path: "{{ _hardbox_bin }}"
+  register: _hardbox_stat
+
+- name: Get installed hardbox version
+  ansible.builtin.command: "{{ _hardbox_bin }} version --short"
+  register: _hardbox_installed_version
+  changed_when: false
+  failed_when: false
+  when: _hardbox_stat.stat.exists
+
+- name: Resolve latest release tag from GitHub API
+  ansible.builtin.uri:
+    url: "{{ _hardbox_releases_api }}"
+    return_content: true
+    headers:
+      Accept: application/vnd.github+json
+  register: _hardbox_release_response
+  when: hardbox_version == "latest"
+  delegate_to: localhost
+  run_once: true
+
+- name: Set resolved version fact
+  ansible.builtin.set_fact:
+    _hardbox_resolved_version: >-
+      {{
+        (hardbox_version == 'latest')
+        | ternary(
+            _hardbox_release_response.json.tag_name,
+            hardbox_version
+          )
+      }}
+
+- name: Skip install if version already matches
+  ansible.builtin.debug:
+    msg: >
+      hardbox {{ _hardbox_resolved_version }} already installed — skipping.
+      Set hardbox_force_reinstall=true to override.
+  when:
+    - _hardbox_stat.stat.exists
+    - not hardbox_force_reinstall | bool
+    - _hardbox_installed_version.stdout is defined
+    - _hardbox_resolved_version in _hardbox_installed_version.stdout
+
+- name: Download hardbox binary
+  ansible.builtin.get_url:
+    url: >-
+      {{ _hardbox_release_base_url }}/{{ _hardbox_resolved_version }}/{{ _hardbox_binary_name }}
+    dest: "{{ hardbox_tmp_dir }}/hardbox"
+    mode: "0755"
+    force: true
+  when: >
+    not _hardbox_stat.stat.exists
+    or hardbox_force_reinstall | bool
+    or (_hardbox_installed_version.stdout is defined
+        and _hardbox_resolved_version not in _hardbox_installed_version.stdout)
+
+- name: Download hardbox checksum file
+  ansible.builtin.get_url:
+    url: >-
+      {{ _hardbox_release_base_url }}/{{ _hardbox_resolved_version }}/hardbox_{{ _hardbox_resolved_version | regex_replace('^v', '') }}_checksums.txt
+    dest: "{{ hardbox_tmp_dir }}/hardbox_checksums.txt"
+    mode: "0644"
+    force: true
+  when: >
+    not _hardbox_stat.stat.exists
+    or hardbox_force_reinstall | bool
+    or (_hardbox_installed_version.stdout is defined
+        and _hardbox_resolved_version not in _hardbox_installed_version.stdout)
+
+- name: Compute SHA-256 of downloaded binary
+  ansible.builtin.stat:
+    path: "{{ hardbox_tmp_dir }}/hardbox"
+    checksum_algorithm: sha256
+  register: _hardbox_download_stat
+  when: >
+    not _hardbox_stat.stat.exists
+    or hardbox_force_reinstall | bool
+    or (_hardbox_installed_version.stdout is defined
+        and _hardbox_resolved_version not in _hardbox_installed_version.stdout)
+
+- name: Read expected checksum from file
+  ansible.builtin.shell: >
+    grep "{{ _hardbox_binary_name }}" {{ hardbox_tmp_dir }}/hardbox_checksums.txt | awk '{print $1}'
+  register: _hardbox_expected_checksum
+  changed_when: false
+  when: _hardbox_download_stat is not skipped
+
+- name: Verify checksum integrity
+  ansible.builtin.fail:
+    msg: >
+      Checksum mismatch for hardbox binary!
+      Expected: {{ _hardbox_expected_checksum.stdout }}
+      Got:      {{ _hardbox_download_stat.stat.checksum }}
+      Aborting installation.
+  when:
+    - _hardbox_download_stat is not skipped
+    - _hardbox_expected_checksum.stdout != _hardbox_download_stat.stat.checksum
+
+- name: Install hardbox binary
+  ansible.builtin.copy:
+    src: "{{ hardbox_tmp_dir }}/hardbox"
+    dest: "{{ _hardbox_bin }}"
+    mode: "0755"
+    owner: root
+    group: root
+    remote_src: true
+  notify: Verify hardbox installation
+  when: _hardbox_download_stat is not skipped
+
+- name: Upload custom profile to target host
+  ansible.builtin.copy:
+    src: "{{ hardbox_custom_profile_src }}"
+    dest: "{{ _hardbox_custom_profile_dest }}"
+    mode: "0640"
+    owner: root
+    group: root
+  when: hardbox_custom_profile_src | length > 0
+
+- name: Ensure report directory exists
+  ansible.builtin.file:
+    path: "{{ hardbox_report_dir }}"
+    state: directory
+    mode: "0750"
+    owner: root
+    group: root
+
+- name: Clean up temporary files
+  ansible.builtin.file:
+    path: "{{ item }}"
+    state: absent
+  loop:
+    - "{{ hardbox_tmp_dir }}/hardbox"
+    - "{{ hardbox_tmp_dir }}/hardbox_checksums.txt"
+  when: _hardbox_download_stat is not skipped

--- a/ansible-role/hardbox/tasks/main.yml
+++ b/ansible-role/hardbox/tasks/main.yml
@@ -1,0 +1,31 @@
+---
+# hardbox Ansible role — main task entrypoint
+
+- name: Gather OS facts
+  ansible.builtin.setup:
+    gather_subset:
+      - "!all"
+      - min
+  when: ansible_architecture is not defined
+
+- name: Validate target architecture
+  ansible.builtin.fail:
+    msg: >
+      Unsupported architecture: {{ ansible_architecture }}.
+      hardbox supports x86_64 and aarch64.
+  when: ansible_architecture not in _hardbox_arch_map
+
+- name: Install hardbox
+  ansible.builtin.import_tasks: install.yml
+
+- name: Apply hardbox profile
+  ansible.builtin.import_tasks: apply.yml
+  when: hardbox_apply | bool
+
+- name: Audit only (no changes)
+  ansible.builtin.import_tasks: audit.yml
+  when: not (hardbox_apply | bool)
+
+- name: Configure periodic re-hardening timer
+  ansible.builtin.import_tasks: timer.yml
+  when: hardbox_timer_enabled | bool

--- a/ansible-role/hardbox/tasks/timer.yml
+++ b/ansible-role/hardbox/tasks/timer.yml
@@ -1,0 +1,34 @@
+---
+# Configure systemd timer for periodic re-hardening
+
+- name: Deploy hardbox systemd service unit
+  ansible.builtin.template:
+    src: hardbox-harden.service.j2
+    dest: "{{ _hardbox_service_unit }}"
+    mode: "0644"
+    owner: root
+    group: root
+  notify:
+    - Reload systemd daemon
+    - Restart hardbox timer
+
+- name: Deploy hardbox systemd timer unit
+  ansible.builtin.template:
+    src: hardbox-harden.timer.j2
+    dest: "{{ _hardbox_timer_unit }}"
+    mode: "0644"
+    owner: root
+    group: root
+  notify:
+    - Reload systemd daemon
+    - Restart hardbox timer
+
+- name: Flush handlers to activate timer immediately
+  ansible.builtin.meta: flush_handlers
+
+- name: Enable and start hardbox timer
+  ansible.builtin.systemd:
+    name: hardbox-harden.timer
+    enabled: true
+    state: started
+    daemon_reload: true

--- a/ansible-role/hardbox/templates/hardbox-harden.service.j2
+++ b/ansible-role/hardbox/templates/hardbox-harden.service.j2
@@ -1,0 +1,15 @@
+[Unit]
+Description=hardbox system hardening (profile: {{ hardbox_profile }})
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart={{ _hardbox_bin }} apply \
+  --profile {{ hardbox_profile }} \
+  --format {{ hardbox_report_format }} \
+  --output {{ hardbox_report_dir }}/hardbox-periodic-$(date +%%Y%%m%%dT%%H%%M%%SZ).{{ hardbox_report_format }} \
+  --non-interactive
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=hardbox

--- a/ansible-role/hardbox/templates/hardbox-harden.timer.j2
+++ b/ansible-role/hardbox/templates/hardbox-harden.timer.j2
@@ -1,0 +1,11 @@
+[Unit]
+Description=hardbox periodic re-hardening ({{ hardbox_timer_schedule }})
+Requires=hardbox-harden.service
+
+[Timer]
+OnBootSec={{ hardbox_timer_on_boot_sec }}
+OnCalendar={{ hardbox_timer_schedule }}
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/ansible-role/hardbox/vars/main.yml
+++ b/ansible-role/hardbox/vars/main.yml
@@ -1,0 +1,27 @@
+---
+# Internal variables — not intended for end-user override.
+
+# GitHub releases API endpoint
+_hardbox_releases_api: "https://api.github.com/repos/jackby03/hardbox/releases/latest"
+
+# Base URL for release asset downloads
+_hardbox_release_base_url: "https://github.com/jackby03/hardbox/releases/download"
+
+# Mapping of Ansible ansible_architecture to GoRelease GOARCH
+_hardbox_arch_map:
+  x86_64: amd64
+  aarch64: arm64
+  armv7l: arm
+
+# Binary name template (filled at runtime)
+_hardbox_binary_name: "hardbox_Linux_{{ _hardbox_arch_map[ansible_architecture] | default('amd64') }}"
+
+# Path to the installed binary
+_hardbox_bin: "{{ hardbox_install_dir }}/hardbox"
+
+# Custom profile destination path on the target host
+_hardbox_custom_profile_dest: /etc/hardbox/custom-profile.yaml
+
+# Systemd unit paths
+_hardbox_service_unit: /etc/systemd/system/hardbox-harden.service
+_hardbox_timer_unit: /etc/systemd/system/hardbox-harden.timer

--- a/docs/ANSIBLE.md
+++ b/docs/ANSIBLE.md
@@ -1,0 +1,246 @@
+# hardbox — Ansible Role
+
+The `hardbox` Ansible role installs the hardbox binary on target hosts and
+applies a compliance profile. It supports all built-in profiles, custom
+profile files, audit-only mode, report fetching, rollback on failure, and
+a systemd timer for periodic re-hardening.
+
+---
+
+## Installation
+
+### From Ansible Galaxy
+
+```bash
+ansible-galaxy role install jackby03.hardbox
+```
+
+### From this repository
+
+```bash
+ansible-galaxy role install \
+  --roles-path ./roles \
+  git+https://github.com/jackby03/hardbox,main#subdirectory=ansible-role/hardbox
+```
+
+Or add to `requirements.yml`:
+
+```yaml
+roles:
+  - name: jackby03.hardbox
+    src: https://github.com/jackby03/hardbox
+    scm: git
+    version: main
+```
+
+---
+
+## Role Structure
+
+```
+ansible-role/hardbox/
+├── defaults/main.yml          # All user-configurable variables with defaults
+├── vars/main.yml              # Internal variables (arch map, paths, URLs)
+├── tasks/
+│   ├── main.yml               # Entrypoint — orchestrates install, apply/audit, timer
+│   ├── install.yml            # Download binary, verify checksum, install
+│   ├── apply.yml              # hardbox apply with rescue/rollback block
+│   ├── audit.yml              # hardbox audit (read-only)
+│   └── timer.yml              # systemd timer for periodic re-hardening
+├── handlers/main.yml          # Systemd reload, timer restart, install verify
+├── templates/
+│   ├── hardbox-harden.service.j2
+│   └── hardbox-harden.timer.j2
+├── meta/main.yml              # Galaxy metadata, platform support, dependencies
+├── molecule/default/          # Integration tests (Docker + Molecule)
+│   ├── molecule.yml
+│   ├── converge.yml
+│   └── verify.yml
+└── README.md
+```
+
+---
+
+## Quick Start
+
+### 1. Inventory
+
+```ini
+# inventory/hosts
+[web]
+web-01.example.com
+web-02.example.com
+
+[db]
+db-01.example.com
+```
+
+### 2. Playbook
+
+```yaml
+# harden.yml
+- hosts: all
+  become: true
+  roles:
+    - role: jackby03.hardbox
+      vars:
+        hardbox_profile: cis-level1
+        hardbox_fetch_report: true
+```
+
+### 3. Run
+
+```bash
+# Dry-run first
+ansible-playbook harden.yml -i inventory/hosts --extra-vars hardbox_dry_run=true
+
+# Apply hardening
+ansible-playbook harden.yml -i inventory/hosts
+
+# Audit only (no changes)
+ansible-playbook harden.yml -i inventory/hosts --extra-vars hardbox_apply=false
+```
+
+---
+
+## Variable Reference
+
+### Installation
+
+| Variable | Default | Description |
+|---|---|---|
+| `hardbox_version` | `"latest"` | Release tag (`"v0.3.0"`) or `"latest"` |
+| `hardbox_install_dir` | `/usr/local/bin` | Binary destination |
+| `hardbox_force_reinstall` | `false` | Re-install even if version matches |
+
+### Profile
+
+| Variable | Default | Description |
+|---|---|---|
+| `hardbox_profile` | `"production"` | Built-in profile name |
+| `hardbox_custom_profile_src` | `""` | Path to a custom YAML profile on the controller |
+
+### Run mode
+
+| Variable | Default | Description |
+|---|---|---|
+| `hardbox_apply` | `true` | Apply hardening; set `false` for audit-only |
+| `hardbox_dry_run` | `false` | Preview changes without applying |
+| `hardbox_non_interactive` | `true` | Always pass `--non-interactive` |
+
+### Reporting
+
+| Variable | Default | Description |
+|---|---|---|
+| `hardbox_report_format` | `"html"` | `html`, `json`, `text`, `markdown` |
+| `hardbox_report_dir` | `/var/lib/hardbox/reports` | Report dir on target |
+| `hardbox_fetch_report` | `false` | Copy report to controller |
+| `hardbox_fetch_report_dest` | `"{{ playbook_dir }}/hardbox-reports"` | Controller destination |
+
+### Audit thresholds
+
+| Variable | Default | Description |
+|---|---|---|
+| `hardbox_fail_on_critical` | `true` | Fail play on critical findings |
+| `hardbox_fail_on_high` | `true` | Fail play on high findings |
+| `hardbox_fail_on_medium` | `false` | Fail play on medium findings |
+
+### Rollback
+
+| Variable | Default | Description |
+|---|---|---|
+| `hardbox_rollback_on_failure` | `true` | Run `hardbox rollback apply --last` on failure |
+
+### Systemd timer
+
+| Variable | Default | Description |
+|---|---|---|
+| `hardbox_timer_enabled` | `false` | Install systemd re-hardening timer |
+| `hardbox_timer_schedule` | `"daily"` | `OnCalendar` value |
+| `hardbox_timer_on_boot_sec` | `"5min"` | `OnBootSec` value |
+
+---
+
+## Profiles
+
+Any profile shipped in `configs/profiles/` is valid:
+
+| Profile | Framework |
+|---|---|
+| `cis-level1` | CIS Benchmarks Level 1 |
+| `cis-level2` | CIS Benchmarks Level 2 |
+| `pci-dss` | PCI-DSS v4.0 |
+| `stig` | DISA STIG |
+| `hipaa` | HIPAA Security Rule |
+| `iso27001` | ISO/IEC 27001:2022 |
+| `cloud-aws` | CIS AWS Foundations v2.0 |
+| `cloud-gcp` | CIS GCP Foundations v2.0 |
+| `cloud-azure` | CIS Azure Foundations v2.1 |
+| `production` | hardbox curated |
+| `development` | hardbox curated |
+
+---
+
+## Running Integration Tests
+
+Tests use [Molecule](https://ansible.readthedocs.io/projects/molecule/) with Docker.
+
+```bash
+cd ansible-role/hardbox
+
+# Install test dependencies
+pip install molecule molecule-plugins[docker] ansible-lint yamllint
+
+# Run the full test matrix (Ubuntu 22.04, Debian 12, Rocky Linux 9)
+molecule test
+
+# Run only the converge step (faster iteration)
+molecule converge
+
+# Run only the verify step
+molecule verify
+
+# Destroy test containers
+molecule destroy
+```
+
+---
+
+## CI/CD Integration
+
+### GitHub Actions
+
+```yaml
+# .github/workflows/harden.yml
+name: Harden servers
+
+on:
+  push:
+    branches: [main]
+  schedule:
+    - cron: "0 2 * * *"   # nightly re-hardening audit
+
+jobs:
+  harden:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Ansible
+        run: pip install ansible
+
+      - name: Install hardbox role
+        run: ansible-galaxy role install jackby03.hardbox
+
+      - name: Audit compliance
+        run: |
+          ansible-playbook harden.yml \
+            -i inventory/production \
+            --extra-vars "hardbox_apply=false hardbox_fetch_report=true"
+
+      - name: Upload compliance reports
+        uses: actions/upload-artifact@v4
+        with:
+          name: hardbox-reports
+          path: hardbox-reports/
+```


### PR DESCRIPTION
## Summary

Closes #109

Adds `ansible-role/hardbox/` — a Galaxy-compatible Ansible role that wraps the hardbox CLI for Ansible-native deployment, completing the P2 item from the v0.3 roadmap (#112).

## Role features

| Feature | Detail |
|---|---|
| Install | Downloads binary from GitHub releases, verifies SHA-256 checksum, skips if version already matches |
| Apply | `hardbox apply` with `block/rescue` — automatic rollback via `hardbox rollback apply --last` on failure |
| Audit-only | `hardbox audit` (no changes) when `hardbox_apply: false` |
| Custom profile | Upload a local YAML profile to the target host |
| Report fetch | Pull HTML/JSON reports back to the Ansible controller |
| systemd timer | Deploy `hardbox-harden.service` + `.timer` via Jinja2 templates for periodic re-hardening |
| Molecule tests | Docker-based tests on Ubuntu 22.04, Debian 12, Rocky Linux 9 |

## Files changed

| File | Change |
|---|---|
| `ansible-role/hardbox/meta/main.yml` | Galaxy metadata — platforms, tags, license |
| `ansible-role/hardbox/defaults/main.yml` | 15+ documented variables with sensible defaults |
| `ansible-role/hardbox/vars/main.yml` | Internal arch map, paths, GitHub API URLs |
| `ansible-role/hardbox/tasks/main.yml` | Entrypoint — orchestrates install, apply/audit, timer |
| `ansible-role/hardbox/tasks/install.yml` | Download, checksum verify, install binary |
| `ansible-role/hardbox/tasks/apply.yml` | `hardbox apply` with rollback rescue block |
| `ansible-role/hardbox/tasks/audit.yml` | Read-only `hardbox audit` |
| `ansible-role/hardbox/tasks/timer.yml` | systemd timer deployment |
| `ansible-role/hardbox/handlers/main.yml` | daemon-reload, timer restart, install verify |
| `ansible-role/hardbox/templates/*.j2` | systemd service and timer unit templates |
| `ansible-role/hardbox/molecule/default/` | Molecule test suite (molecule.yml, converge.yml, verify.yml) |
| `ansible-role/hardbox/README.md` | Role-level README with examples |
| `docs/ANSIBLE.md` | Full usage guide: install, variables, playbooks, CI/CD |
| `CHANGELOG.md` | [Unreleased] Added entries for role and docs |

## Test plan

- [ ] `molecule test` passes on Ubuntu 22.04, Debian 12, Rocky Linux 9
- [ ] `ansible-lint ansible-role/hardbox/` reports no violations
- [ ] `yamllint ansible-role/hardbox/` reports no errors
- [ ] Role installs hardbox binary with correct permissions (`0755`)
- [ ] Checksum mismatch causes task failure (not silent skip)
- [ ] Rollback task runs when `hardbox apply` fails
- [ ] Report file created in `hardbox_report_dir` after apply
- [ ] systemd timer active when `hardbox_timer_enabled: true`

https://claude.ai/code/session_016UiLjmeSDKyMW1yvK4SVaQ