### PR TITLE
feat(v0.3): add Terraform provider for hardbox (#110)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,8 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - `docs/CLOUD-INIT.md` — usage guide covering quick-start commands, IAM/RBAC requirements, configuration reference, timer management, and troubleshooting for all three cloud-init templates
 - Ansible role (`ansible-role/hardbox/`) — Galaxy-compatible role wrapping the hardbox CLI; supports all profiles, audit-only mode, report fetching, rollback on failure, custom profile upload, and systemd re-hardening timer; includes Molecule integration tests for Ubuntu 22.04, Debian 12, and Rocky Linux 9 ([#109](https://github.com/jackby03/hardbox/issues/109))
 - `docs/ANSIBLE.md` — Ansible role documentation covering installation, variable reference, example playbooks, CI/CD integration, and Molecule test instructions
+- Terraform provider (`terraform-provider/`) — `jackby03/hardbox` provider for the Terraform Registry; exposes `hardbox_apply` resource with SSH-based install, checksum verification, profile selection, findings capture in state, and automatic rollback on destroy; examples for AWS EC2, GCP Compute Engine, and Azure VMs ([#110](https://github.com/jackby03/hardbox/issues/110))
+- `docs/TERRAFORM.md` — provider documentation covering installation, provider/resource schema, per-cloud examples, CI/CD snippets, and build-from-source instructions
 
 ### Changed
 - `install.sh` now resolves release assets via GitHub API instead of hardcoded filenames, improving compatibility across release archive naming formats.
@@ -119,7 +121,6 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Planned for v0.3
 - `nist-800-53` profile
-- Terraform provisioner plugin
 - cloud-init support
 
 ---

--- a/docs/TERRAFORM.md
+++ b/docs/TERRAFORM.md
@@ -1,0 +1,226 @@
+# hardbox — Terraform Provider
+
+The `jackby03/hardbox` Terraform provider applies OS hardening to remote Linux
+hosts as part of your infrastructure-as-code workflow. It installs the hardbox
+binary, runs a compliance profile, and surfaces audit findings in Terraform state.
+
+Supported targets: **AWS EC2**, **GCP Compute Engine**, **Azure VMs**, and any
+SSH-accessible Linux host.
+
+---
+
+## Installation
+
+Add the provider to your `required_providers` block:
+
+```hcl
+terraform {
+  required_providers {
+    hardbox = {
+      source  = "jackby03/hardbox"
+      version = "~> 0.3"
+    }
+  }
+}
+```
+
+```bash
+terraform init
+```
+
+---
+
+## Provider Configuration
+
+```hcl
+provider "hardbox" {
+  # Optional: pin the hardbox binary version installed on all managed hosts.
+  # Defaults to "latest" if omitted.
+  hardbox_version = "v0.3.0"
+}
+```
+
+| Argument | Type | Default | Description |
+|---|---|---|---|
+| `hardbox_version` | string | `"latest"` | hardbox release tag to install on remote hosts |
+
+---
+
+## Resource: `hardbox_apply`
+
+Provisions a remote Linux host with hardbox OS hardening.
+
+### What it does
+
+1. Connects to the host over SSH.
+2. Downloads the hardbox binary and verifies its SHA-256 checksum.
+3. Runs `hardbox apply` with the selected compliance profile.
+4. Captures the audit report and surfaces finding counts in state.
+5. On `terraform destroy`, runs `hardbox rollback apply --last`.
+
+### Arguments
+
+#### SSH connection
+
+| Argument | Required | Description |
+|---|---|---|
+| `host` | yes | IP address or hostname of the target |
+| `port` | no | SSH port (default: `22`) |
+| `user` | no | SSH username (default: `root`) |
+| `private_key` | no | PEM-encoded SSH private key |
+| `agent_socket` | no | Path to SSH agent socket (`$SSH_AUTH_SOCK`) |
+
+#### hardbox options
+
+| Argument | Default | Description |
+|---|---|---|
+| `profile` | required | Compliance profile name |
+| `hardbox_version` | provider default | Override version for this resource |
+| `dry_run` | `false` | Preview changes without applying |
+| `rollback_on_failure` | `true` | Rollback automatically on failure |
+| `report_format` | `"json"` | `json`, `html`, `text`, `markdown` |
+| `fail_on_critical` | `true` | Fail apply on critical findings |
+| `fail_on_high` | `true` | Fail apply on high findings |
+
+### Computed attributes
+
+| Attribute | Description |
+|---|---|
+| `id` | `<host>:<profile>@<applied_at>` |
+| `applied_at` | RFC3339 timestamp of last apply |
+| `installed_version` | hardbox version installed on the host |
+| `report_content` | Full audit report (JSON/HTML/text) |
+| `findings` | Map of severity counts: `{critical, high, medium, low, info}` |
+
+---
+
+## Examples
+
+### AWS EC2
+
+```hcl
+resource "hardbox_apply" "web" {
+  host        = aws_instance.web.public_ip
+  user        = "ubuntu"
+  private_key = file("~/.ssh/id_rsa")
+
+  profile             = "cloud-aws"
+  report_format       = "json"
+  fail_on_critical    = true
+  fail_on_high        = true
+  rollback_on_failure = true
+}
+
+output "findings" {
+  value = hardbox_apply.web.findings
+}
+```
+
+Full example: [`examples/aws/`](../terraform-provider/examples/aws/)
+
+### GCP Compute Engine
+
+```hcl
+resource "hardbox_apply" "web" {
+  host        = google_compute_instance.web.network_interface[0].network_ip
+  user        = "ubuntu"
+  private_key = file("~/.ssh/id_rsa")
+
+  profile       = "cloud-gcp"
+  report_format = "json"
+}
+```
+
+Full example: [`examples/gcp/`](../terraform-provider/examples/gcp/)
+
+### Azure VM
+
+```hcl
+resource "hardbox_apply" "vm" {
+  host        = azurerm_network_interface.nic.private_ip_address
+  user        = "azureuser"
+  private_key = file("~/.ssh/id_rsa")
+
+  profile       = "cloud-azure"
+  report_format = "json"
+}
+```
+
+Full example: [`examples/azure/`](../terraform-provider/examples/azure/)
+
+### Audit-only (no changes)
+
+```hcl
+resource "hardbox_apply" "audit" {
+  host        = var.host_ip
+  user        = "ubuntu"
+  private_key = file(var.key_path)
+
+  profile  = "cis-level2"
+  dry_run  = true   # --dry-run: no changes applied
+}
+```
+
+---
+
+## Profiles
+
+| Profile | Framework |
+|---|---|
+| `cis-level1` | CIS Benchmarks Level 1 |
+| `cis-level2` | CIS Benchmarks Level 2 |
+| `pci-dss` | PCI-DSS v4.0 |
+| `stig` | DISA STIG |
+| `hipaa` | HIPAA Security Rule |
+| `iso27001` | ISO/IEC 27001:2022 |
+| `cloud-aws` | CIS AWS Foundations v2.0 |
+| `cloud-gcp` | CIS GCP Foundations v2.0 |
+| `cloud-azure` | CIS Azure Foundations v2.1 |
+| `production` | hardbox curated |
+| `development` | hardbox curated |
+
+---
+
+## CI/CD Integration
+
+### GitHub Actions
+
+```yaml
+- name: Terraform apply (with hardbox hardening)
+  run: terraform apply -auto-approve
+  env:
+    TF_VAR_private_key: ${{ secrets.SSH_PRIVATE_KEY }}
+```
+
+### GitLab CI
+
+```yaml
+terraform:
+  script:
+    - terraform init
+    - terraform apply -auto-approve
+  variables:
+    TF_VAR_private_key: $SSH_PRIVATE_KEY
+```
+
+---
+
+## Building from source
+
+```bash
+cd terraform-provider/
+go build -o terraform-provider-hardbox .
+
+# Install locally for testing
+mkdir -p ~/.terraform.d/plugins/registry.terraform.io/jackby03/hardbox/0.3.0/linux_amd64
+cp terraform-provider-hardbox \
+  ~/.terraform.d/plugins/registry.terraform.io/jackby03/hardbox/0.3.0/linux_amd64/
+```
+
+---
+
+## Publishing to Terraform Registry
+
+The provider is published to the [Terraform Registry](https://registry.terraform.io/providers/jackby03/hardbox)
+via GitHub Actions on release tag push. The registry indexes `terraform-provider/`
+as the provider source directory.

--- a/terraform-provider/examples/aws/main.tf
+++ b/terraform-provider/examples/aws/main.tf
@@ -1,0 +1,86 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+    hardbox = {
+      source  = "jackby03/hardbox"
+      version = "~> 0.3"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+}
+
+provider "hardbox" {
+  hardbox_version = "latest"
+}
+
+# ── EC2 instance ──────────────────────────────────────────────────────────────
+
+resource "aws_instance" "web" {
+  ami                    = var.ami_id
+  instance_type          = "t3.micro"
+  key_name               = var.key_name
+  vpc_security_group_ids = [aws_security_group.web.id]
+  subnet_id              = var.subnet_id
+
+  tags = {
+    Name = "hardbox-demo"
+  }
+}
+
+resource "aws_security_group" "web" {
+  name        = "hardbox-demo-sg"
+  description = "hardbox demo — SSH restricted to known CIDRs"
+  vpc_id      = var.vpc_id
+
+  ingress {
+    description = "SSH from bastion/VPN only"
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = var.ssh_allowed_cidrs
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+# ── hardbox hardening ─────────────────────────────────────────────────────────
+
+resource "hardbox_apply" "web" {
+  host        = aws_instance.web.public_ip
+  user        = "ubuntu"
+  private_key = file(var.private_key_path)
+
+  profile       = "cloud-aws"
+  report_format = "json"
+
+  fail_on_critical   = true
+  fail_on_high       = true
+  rollback_on_failure = true
+
+  depends_on = [aws_instance.web]
+}
+
+# ── Outputs ───────────────────────────────────────────────────────────────────
+
+output "instance_id" {
+  value = aws_instance.web.id
+}
+
+output "hardbox_applied_at" {
+  value = hardbox_apply.web.applied_at
+}
+
+output "hardbox_findings" {
+  value = hardbox_apply.web.findings
+}

--- a/terraform-provider/examples/aws/main.tf
+++ b/terraform-provider/examples/aws/main.tf
@@ -60,12 +60,14 @@ resource "hardbox_apply" "web" {
   host        = aws_instance.web.public_ip
   user        = "ubuntu"
   private_key = file(var.private_key_path)
+  # Obtain with: ssh-keyscan -t ed25519 <ip> | awk '{print $3}'
+  host_key    = var.host_public_key
 
   profile       = "cloud-aws"
   report_format = "json"
 
-  fail_on_critical   = true
-  fail_on_high       = true
+  fail_on_critical    = true
+  fail_on_high        = true
   rollback_on_failure = true
 
   depends_on = [aws_instance.web]

--- a/terraform-provider/examples/aws/variables.tf
+++ b/terraform-provider/examples/aws/variables.tf
@@ -35,3 +35,8 @@ variable "private_key_path" {
   type        = string
   default     = "~/.ssh/id_rsa"
 }
+
+variable "host_public_key" {
+  description = "Base64-encoded SSH public host key (from ssh-keyscan -t ed25519 <host> | awk '{print $3}')."
+  type        = string
+}

--- a/terraform-provider/examples/aws/variables.tf
+++ b/terraform-provider/examples/aws/variables.tf
@@ -1,0 +1,37 @@
+variable "aws_region" {
+  description = "AWS region to deploy into."
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "ami_id" {
+  description = "Ubuntu 22.04 LTS AMI ID for the target region."
+  type        = string
+}
+
+variable "key_name" {
+  description = "Name of the EC2 key pair for SSH access."
+  type        = string
+}
+
+variable "vpc_id" {
+  description = "VPC ID where the instance will be launched."
+  type        = string
+}
+
+variable "subnet_id" {
+  description = "Subnet ID for the EC2 instance."
+  type        = string
+}
+
+variable "ssh_allowed_cidrs" {
+  description = "CIDR blocks allowed to reach SSH (port 22)."
+  type        = list(string)
+  default     = ["10.0.0.0/8"]
+}
+
+variable "private_key_path" {
+  description = "Local path to the SSH private key file."
+  type        = string
+  default     = "~/.ssh/id_rsa"
+}

--- a/terraform-provider/examples/azure/main.tf
+++ b/terraform-provider/examples/azure/main.tf
@@ -1,0 +1,115 @@
+terraform {
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 3.0"
+    }
+    hardbox = {
+      source  = "jackby03/hardbox"
+      version = "~> 0.3"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {}
+}
+
+provider "hardbox" {
+  hardbox_version = "latest"
+}
+
+# ── Azure VM ──────────────────────────────────────────────────────────────────
+
+resource "azurerm_resource_group" "rg" {
+  name     = "hardbox-demo-rg"
+  location = var.location
+}
+
+resource "azurerm_virtual_network" "vnet" {
+  name                = "hardbox-vnet"
+  address_space       = ["10.0.0.0/16"]
+  location            = azurerm_resource_group.rg.location
+  resource_group_name = azurerm_resource_group.rg.name
+}
+
+resource "azurerm_subnet" "subnet" {
+  name                 = "hardbox-subnet"
+  resource_group_name  = azurerm_resource_group.rg.name
+  virtual_network_name = azurerm_virtual_network.vnet.name
+  address_prefixes     = ["10.0.1.0/24"]
+}
+
+resource "azurerm_network_interface" "nic" {
+  name                = "hardbox-nic"
+  location            = azurerm_resource_group.rg.location
+  resource_group_name = azurerm_resource_group.rg.name
+
+  ip_configuration {
+    name                          = "internal"
+    subnet_id                     = azurerm_subnet.subnet.id
+    private_ip_address_allocation = "Dynamic"
+  }
+}
+
+resource "azurerm_linux_virtual_machine" "vm" {
+  name                = "hardbox-demo"
+  resource_group_name = azurerm_resource_group.rg.name
+  location            = azurerm_resource_group.rg.location
+  size                = "Standard_B2s"
+  admin_username      = "azureuser"
+
+  network_interface_ids = [azurerm_network_interface.nic.id]
+
+  admin_ssh_key {
+    username   = "azureuser"
+    public_key = file(var.ssh_public_key_path)
+  }
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  source_image_reference {
+    publisher = "Canonical"
+    offer     = "0001-com-ubuntu-server-jammy"
+    sku       = "22_04-lts"
+    version   = "latest"
+  }
+
+  identity {
+    type = "SystemAssigned"
+  }
+}
+
+# ── hardbox hardening ─────────────────────────────────────────────────────────
+
+resource "hardbox_apply" "vm" {
+  host        = azurerm_network_interface.nic.private_ip_address
+  user        = "azureuser"
+  private_key = file(var.ssh_private_key_path)
+
+  profile       = "cloud-azure"
+  report_format = "json"
+
+  fail_on_critical    = true
+  fail_on_high        = true
+  rollback_on_failure = true
+
+  depends_on = [azurerm_linux_virtual_machine.vm]
+}
+
+# ── Outputs ───────────────────────────────────────────────────────────────────
+
+output "vm_name" {
+  value = azurerm_linux_virtual_machine.vm.name
+}
+
+output "hardbox_applied_at" {
+  value = hardbox_apply.vm.applied_at
+}
+
+output "hardbox_findings" {
+  value = hardbox_apply.vm.findings
+}

--- a/terraform-provider/examples/gcp/main.tf
+++ b/terraform-provider/examples/gcp/main.tf
@@ -1,0 +1,87 @@
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 5.0"
+    }
+    hardbox = {
+      source  = "jackby03/hardbox"
+      version = "~> 0.3"
+    }
+  }
+}
+
+provider "google" {
+  project = var.project_id
+  region  = var.region
+  zone    = var.zone
+}
+
+provider "hardbox" {
+  hardbox_version = "latest"
+}
+
+# ── Compute Engine VM ─────────────────────────────────────────────────────────
+
+resource "google_compute_instance" "web" {
+  name         = "hardbox-demo"
+  machine_type = "e2-medium"
+  zone         = var.zone
+
+  boot_disk {
+    initialize_params {
+      image = "ubuntu-os-cloud/ubuntu-2204-lts"
+    }
+  }
+
+  network_interface {
+    network    = "default"
+    subnetwork = var.subnetwork
+    # No external IP — access via IAP TCP tunnel
+  }
+
+  service_account {
+    email  = var.service_account_email
+    scopes = ["cloud-platform"]
+  }
+
+  shielded_instance_config {
+    enable_secure_boot          = true
+    enable_vtpm                 = true
+    enable_integrity_monitoring = true
+  }
+
+  tags = ["hardbox-demo"]
+}
+
+# ── hardbox hardening ─────────────────────────────────────────────────────────
+
+resource "hardbox_apply" "web" {
+  # Use internal IP; access via IAP TCP tunnel or private network
+  host        = google_compute_instance.web.network_interface[0].network_ip
+  user        = "ubuntu"
+  private_key = file(var.private_key_path)
+
+  profile       = "cloud-gcp"
+  report_format = "json"
+
+  fail_on_critical    = true
+  fail_on_high        = true
+  rollback_on_failure = true
+
+  depends_on = [google_compute_instance.web]
+}
+
+# ── Outputs ───────────────────────────────────────────────────────────────────
+
+output "instance_name" {
+  value = google_compute_instance.web.name
+}
+
+output "hardbox_applied_at" {
+  value = hardbox_apply.web.applied_at
+}
+
+output "hardbox_findings" {
+  value = hardbox_apply.web.findings
+}

--- a/terraform-provider/go.mod
+++ b/terraform-provider/go.mod
@@ -1,0 +1,9 @@
+module github.com/jackby03/terraform-provider-hardbox
+
+go 1.22
+
+require (
+	github.com/hashicorp/terraform-plugin-framework v1.11.0
+	github.com/hashicorp/terraform-plugin-log v0.9.0
+	github.com/hashicorp/terraform-plugin-go v0.23.0
+)

--- a/terraform-provider/internal/hardbox/install.go
+++ b/terraform-provider/internal/hardbox/install.go
@@ -1,0 +1,151 @@
+package hardbox
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+)
+
+// Install downloads and installs the hardbox binary on the remote host.
+// Returns the installed version string.
+func Install(ctx context.Context, conn *SSHClient, version string) (string, error) {
+	// Resolve "latest" to a concrete tag.
+	if version == "latest" {
+		resolved, err := resolveLatestVersion()
+		if err != nil {
+			return "", fmt.Errorf("resolve latest hardbox version: %w", err)
+		}
+		version = resolved
+		tflog.Debug(ctx, "Resolved latest hardbox version", map[string]any{"version": version})
+	}
+
+	// Check if already installed at the correct version.
+	existingOut, _ := conn.Run("hardbox version --short 2>/dev/null || true")
+	if strings.Contains(existingOut, version) {
+		tflog.Debug(ctx, "hardbox already at target version — skipping install", map[string]any{"version": version})
+		return version, nil
+	}
+
+	// Detect remote architecture.
+	archOut, err := conn.Run("uname -m")
+	if err != nil {
+		return "", fmt.Errorf("detect remote architecture: %w", err)
+	}
+	goarch, ok := map[string]string{
+		"x86_64":  "amd64",
+		"aarch64": "arm64",
+	}[strings.TrimSpace(archOut)]
+	if !ok {
+		return "", fmt.Errorf("unsupported architecture: %s", archOut)
+	}
+
+	binaryName := fmt.Sprintf("hardbox_Linux_%s", goarch)
+	versionTag := strings.TrimPrefix(version, "v")
+	checksumFile := fmt.Sprintf("hardbox_%s_checksums.txt", versionTag)
+	baseURL := fmt.Sprintf("https://github.com/jackby03/hardbox/releases/download/%s", version)
+
+	installScript := fmt.Sprintf(`
+set -euo pipefail
+mkdir -p /var/lib/hardbox/reports
+curl -fsSL "%s/%s" -o /tmp/hb_binary
+curl -fsSL "%s/%s" -o /tmp/hb_checksums
+
+EXPECTED=$(grep "%s" /tmp/hb_checksums | awk '{print $1}')
+ACTUAL=$(sha256sum /tmp/hb_binary | awk '{print $1}')
+if [ "$EXPECTED" != "$ACTUAL" ]; then
+  echo "Checksum mismatch: expected=$EXPECTED actual=$ACTUAL" >&2
+  exit 1
+fi
+
+install -m 0755 /tmp/hb_binary /usr/local/bin/hardbox
+rm -f /tmp/hb_binary /tmp/hb_checksums
+hardbox version
+`, baseURL, binaryName, baseURL, checksumFile, binaryName)
+
+	out, err := conn.Run(installScript)
+	if err != nil {
+		return "", fmt.Errorf("install hardbox %s: %w\nOutput: %s", version, err, out)
+	}
+
+	// Extract version from output.
+	installed := strings.TrimSpace(out)
+	return installed, nil
+}
+
+// resolveLatestVersion queries the GitHub API for the latest hardbox release tag.
+func resolveLatestVersion() (string, error) {
+	resp, err := http.Get("https://api.github.com/repos/jackby03/hardbox/releases/latest") //nolint:noctx
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+
+	var release struct {
+		TagName string `json:"tag_name"`
+	}
+	if err := json.Unmarshal(body, &release); err != nil {
+		return "", err
+	}
+	if release.TagName == "" {
+		return "", fmt.Errorf("empty tag_name in GitHub API response")
+	}
+	return release.TagName, nil
+}
+
+// ParseFindings extracts severity counts from a hardbox JSON report.
+// Returns a map of {"critical": "N", "high": "N", "medium": "N", "low": "N", "info": "N"}.
+// Non-JSON report formats return an empty map.
+func ParseFindings(reportContent, format string) map[string]string {
+	result := map[string]string{
+		"critical": "0",
+		"high":     "0",
+		"medium":   "0",
+		"low":      "0",
+		"info":     "0",
+	}
+
+	if format != "json" || reportContent == "" {
+		return result
+	}
+
+	var report struct {
+		Summary struct {
+			Critical int `json:"critical"`
+			High     int `json:"high"`
+			Medium   int `json:"medium"`
+			Low      int `json:"low"`
+			Info     int `json:"info"`
+		} `json:"summary"`
+	}
+
+	// Attempt to find the summary block anywhere in the JSON.
+	re := regexp.MustCompile(`"summary"\s*:\s*\{[^}]+\}`)
+	match := re.FindString(reportContent)
+	if match == "" {
+		return result
+	}
+
+	wrapped := fmt.Sprintf(`{%s}`, match)
+	if err := json.Unmarshal([]byte(wrapped), &report); err != nil {
+		return result
+	}
+
+	result["critical"] = strconv.Itoa(report.Summary.Critical)
+	result["high"] = strconv.Itoa(report.Summary.High)
+	result["medium"] = strconv.Itoa(report.Summary.Medium)
+	result["low"] = strconv.Itoa(report.Summary.Low)
+	result["info"] = strconv.Itoa(report.Summary.Info)
+	return result
+}

--- a/terraform-provider/internal/hardbox/ssh.go
+++ b/terraform-provider/internal/hardbox/ssh.go
@@ -3,6 +3,7 @@
 package hardbox
 
 import (
+	"encoding/base64"
 	"fmt"
 	"net"
 	"os"
@@ -11,6 +12,7 @@ import (
 
 	"golang.org/x/crypto/ssh"
 	"golang.org/x/crypto/ssh/agent"
+	"golang.org/x/crypto/ssh/knownhosts"
 )
 
 // SSHConfig holds the connection parameters for a remote host.
@@ -20,6 +22,12 @@ type SSHConfig struct {
 	User        string
 	PrivateKey  string
 	AgentSocket string
+
+	// HostKey is the base64-encoded public host key of the target server
+	// (the value from `ssh-keyscan` or `~/.ssh/known_hosts`).
+	// When set, the connection is verified against this exact key.
+	// When empty, the system known_hosts file (~/.ssh/known_hosts) is used.
+	HostKey string
 }
 
 // SSHClient wraps an active SSH connection.
@@ -29,6 +37,8 @@ type SSHClient struct {
 
 // NewSSHClient establishes an SSH connection using either a private key or
 // the SSH agent identified by AgentSocket.
+// Host key verification is performed against HostKey (if set) or the
+// system known_hosts file. Connections with unknown host keys are rejected.
 func NewSSHClient(cfg SSHConfig) (*SSHClient, error) {
 	port := cfg.Port
 	if port == 0 {
@@ -39,6 +49,7 @@ func NewSSHClient(cfg SSHConfig) (*SSHClient, error) {
 		user = "root"
 	}
 
+	// --- Authentication ---
 	var authMethods []ssh.AuthMethod
 
 	if cfg.PrivateKey != "" {
@@ -71,10 +82,16 @@ func NewSSHClient(cfg SSHConfig) (*SSHClient, error) {
 		return nil, fmt.Errorf("no SSH authentication method available: set private_key or agent_socket")
 	}
 
+	// --- Host key verification ---
+	hostKeyCallback, err := buildHostKeyCallback(cfg.Host, port, cfg.HostKey)
+	if err != nil {
+		return nil, err
+	}
+
 	clientCfg := &ssh.ClientConfig{
 		User:            user,
 		Auth:            authMethods,
-		HostKeyCallback: ssh.InsecureIgnoreHostKey(), //nolint:gosec // users should configure known_hosts in production
+		HostKeyCallback: hostKeyCallback,
 		Timeout:         30 * time.Second,
 	}
 
@@ -85,6 +102,59 @@ func NewSSHClient(cfg SSHConfig) (*SSHClient, error) {
 	}
 
 	return &SSHClient{client: client}, nil
+}
+
+// buildHostKeyCallback returns the appropriate ssh.HostKeyCallback:
+//   - If hostKey is provided: verify against that specific key only.
+//   - Otherwise: verify against the system known_hosts file.
+func buildHostKeyCallback(host string, port int, hostKey string) (ssh.HostKeyCallback, error) {
+	if hostKey != "" {
+		return fixedHostKeyCallback(hostKey)
+	}
+	return knownHostsCallback()
+}
+
+// fixedHostKeyCallback parses a base64-encoded public key and returns a
+// callback that accepts only that exact key.
+func fixedHostKeyCallback(hostKeyB64 string) (ssh.HostKeyCallback, error) {
+	keyBytes, err := base64.StdEncoding.DecodeString(hostKeyB64)
+	if err != nil {
+		return nil, fmt.Errorf("decode host_key (expected base64): %w", err)
+	}
+
+	pubKey, err := ssh.ParsePublicKey(keyBytes)
+	if err != nil {
+		return nil, fmt.Errorf("parse host_key as SSH public key: %w", err)
+	}
+
+	return ssh.FixedHostKey(pubKey), nil
+}
+
+// knownHostsCallback returns a callback that verifies hosts against the
+// system known_hosts file (~/.ssh/known_hosts).
+// Returns an error if the file does not exist or cannot be parsed.
+func knownHostsCallback() (ssh.HostKeyCallback, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return nil, fmt.Errorf("determine home directory for known_hosts lookup: %w", err)
+	}
+
+	knownHostsPath := fmt.Sprintf("%s/.ssh/known_hosts", home)
+	if _, err := os.Stat(knownHostsPath); os.IsNotExist(err) {
+		return nil, fmt.Errorf(
+			"host_key is not set and %s does not exist: "+
+				"provide the host's public key via the host_key argument "+
+				"(obtain with: ssh-keyscan -t ed25519 <host> | awk '{print $3}')",
+			knownHostsPath,
+		)
+	}
+
+	cb, err := knownhosts.New(knownHostsPath)
+	if err != nil {
+		return nil, fmt.Errorf("parse known_hosts file %s: %w", knownHostsPath, err)
+	}
+
+	return cb, nil
 }
 
 // Run executes a command on the remote host and returns combined stdout+stderr.

--- a/terraform-provider/internal/hardbox/ssh.go
+++ b/terraform-provider/internal/hardbox/ssh.go
@@ -1,0 +1,114 @@
+// Package hardbox provides SSH utilities and hardbox CLI helpers
+// used by the Terraform provider resource implementation.
+package hardbox
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"strings"
+	"time"
+
+	"golang.org/x/crypto/ssh"
+	"golang.org/x/crypto/ssh/agent"
+)
+
+// SSHConfig holds the connection parameters for a remote host.
+type SSHConfig struct {
+	Host        string
+	Port        int
+	User        string
+	PrivateKey  string
+	AgentSocket string
+}
+
+// SSHClient wraps an active SSH connection.
+type SSHClient struct {
+	client *ssh.Client
+}
+
+// NewSSHClient establishes an SSH connection using either a private key or
+// the SSH agent identified by AgentSocket.
+func NewSSHClient(cfg SSHConfig) (*SSHClient, error) {
+	port := cfg.Port
+	if port == 0 {
+		port = 22
+	}
+	user := cfg.User
+	if user == "" {
+		user = "root"
+	}
+
+	var authMethods []ssh.AuthMethod
+
+	if cfg.PrivateKey != "" {
+		signer, err := ssh.ParsePrivateKey([]byte(cfg.PrivateKey))
+		if err != nil {
+			return nil, fmt.Errorf("parse private key: %w", err)
+		}
+		authMethods = append(authMethods, ssh.PublicKeys(signer))
+	}
+
+	if cfg.AgentSocket != "" {
+		sock, err := net.Dial("unix", cfg.AgentSocket)
+		if err != nil {
+			return nil, fmt.Errorf("connect to SSH agent socket %s: %w", cfg.AgentSocket, err)
+		}
+		authMethods = append(authMethods, ssh.PublicKeysCallback(agent.NewClient(sock).Signers))
+	}
+
+	if len(authMethods) == 0 {
+		// Fall back to SSH_AUTH_SOCK environment variable.
+		if sock := os.Getenv("SSH_AUTH_SOCK"); sock != "" {
+			conn, err := net.Dial("unix", sock)
+			if err == nil {
+				authMethods = append(authMethods, ssh.PublicKeysCallback(agent.NewClient(conn).Signers))
+			}
+		}
+	}
+
+	if len(authMethods) == 0 {
+		return nil, fmt.Errorf("no SSH authentication method available: set private_key or agent_socket")
+	}
+
+	clientCfg := &ssh.ClientConfig{
+		User:            user,
+		Auth:            authMethods,
+		HostKeyCallback: ssh.InsecureIgnoreHostKey(), //nolint:gosec // users should configure known_hosts in production
+		Timeout:         30 * time.Second,
+	}
+
+	addr := fmt.Sprintf("%s:%d", cfg.Host, port)
+	client, err := ssh.Dial("tcp", addr, clientCfg)
+	if err != nil {
+		return nil, fmt.Errorf("ssh dial %s: %w", addr, err)
+	}
+
+	return &SSHClient{client: client}, nil
+}
+
+// Run executes a command on the remote host and returns combined stdout+stderr.
+func (c *SSHClient) Run(cmd string) (string, error) {
+	sess, err := c.client.NewSession()
+	if err != nil {
+		return "", fmt.Errorf("new SSH session: %w", err)
+	}
+	defer sess.Close()
+
+	out, err := sess.CombinedOutput(cmd)
+	return strings.TrimSpace(string(out)), err
+}
+
+// ReadFile reads the contents of a remote file.
+func (c *SSHClient) ReadFile(path string) (string, error) {
+	out, err := c.Run(fmt.Sprintf("cat %s", path))
+	if err != nil {
+		return "", fmt.Errorf("read remote file %s: %w", path, err)
+	}
+	return out, nil
+}
+
+// Close closes the underlying SSH connection.
+func (c *SSHClient) Close() error {
+	return c.client.Close()
+}

--- a/terraform-provider/internal/provider/provider.go
+++ b/terraform-provider/internal/provider/provider.go
@@ -1,0 +1,94 @@
+// Package provider implements the hardbox Terraform provider.
+// The provider exposes a single resource — hardbox_apply — which provisions
+// a remote Linux host using the hardbox hardening CLI.
+package provider
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/function"
+	"github.com/hashicorp/terraform-plugin-framework/provider"
+	"github.com/hashicorp/terraform-plugin-framework/provider/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// Ensure hardboxProvider implements the provider.Provider interface.
+var _ provider.Provider = &hardboxProvider{}
+var _ provider.ProviderWithFunctions = &hardboxProvider{}
+
+// hardboxProvider is the top-level provider struct.
+type hardboxProvider struct {
+	version string
+}
+
+// hardboxProviderModel mirrors the provider-level HCL configuration block.
+type hardboxProviderModel struct {
+	// HardboxVersion pins the hardbox binary version installed on remote hosts.
+	// Defaults to "latest" when omitted.
+	HardboxVersion types.String `tfsdk:"hardbox_version"`
+}
+
+// New returns a factory function for the hardbox provider.
+func New(version string) func() provider.Provider {
+	return func() provider.Provider {
+		return &hardboxProvider{version: version}
+	}
+}
+
+func (p *hardboxProvider) Metadata(_ context.Context, _ provider.MetadataRequest, resp *provider.MetadataResponse) {
+	resp.TypeName = "hardbox"
+	resp.Version = p.version
+}
+
+func (p *hardboxProvider) Schema(_ context.Context, _ provider.SchemaRequest, resp *provider.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		MarkdownDescription: `
+The **hardbox** provider provisions Linux system hardening on remote hosts using
+the [hardbox](https://github.com/jackby03/hardbox) CLI.
+
+It downloads the hardbox binary, applies a compliance profile, and captures
+the audit report — all within a single ` + "`terraform apply`" + ` run.
+
+Supported targets: AWS EC2, GCP Compute Engine, Azure VMs, and any SSH-accessible Linux host.
+`,
+		Attributes: map[string]schema.Attribute{
+			"hardbox_version": schema.StringAttribute{
+				Optional:            true,
+				MarkdownDescription: "hardbox release to install on remote hosts (e.g. `v0.3.0`). Defaults to `latest`.",
+			},
+		},
+	}
+}
+
+func (p *hardboxProvider) Configure(ctx context.Context, req provider.ConfigureRequest, resp *provider.ConfigureResponse) {
+	var config hardboxProviderModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	version := "latest"
+	if !config.HardboxVersion.IsNull() && !config.HardboxVersion.IsUnknown() {
+		version = config.HardboxVersion.ValueString()
+	}
+
+	// Pass the resolved version to resources via provider data.
+	resp.ResourceData = version
+	resp.DataSourceData = version
+}
+
+func (p *hardboxProvider) Resources(_ context.Context) []func() resource.Resource {
+	return []func() resource.Resource{
+		NewHardboxApplyResource,
+	}
+}
+
+func (p *hardboxProvider) DataSources(_ context.Context) []func() datasource.DataSource {
+	return []func() datasource.DataSource{}
+}
+
+func (p *hardboxProvider) Functions(_ context.Context) []func() function.Function {
+	return []func() function.Function{}
+}

--- a/terraform-provider/internal/provider/resource_hardbox_apply.go
+++ b/terraform-provider/internal/provider/resource_hardbox_apply.go
@@ -1,0 +1,391 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/jackby03/terraform-provider-hardbox/internal/hardbox"
+)
+
+// Ensure hardboxApplyResource implements resource.Resource.
+var _ resource.Resource = &hardboxApplyResource{}
+var _ resource.ResourceWithImportState = &hardboxApplyResource{}
+
+// hardboxApplyResource provisions a remote host with hardbox.
+type hardboxApplyResource struct {
+	hardboxVersion string
+}
+
+// hardboxApplyModel is the Terraform state schema for hardbox_apply.
+type hardboxApplyModel struct {
+	// --- Identity ---
+	ID types.String `tfsdk:"id"`
+
+	// --- SSH connection ---
+	Host        types.String `tfsdk:"host"`
+	Port        types.Int64  `tfsdk:"port"`
+	User        types.String `tfsdk:"user"`
+	PrivateKey  types.String `tfsdk:"private_key"`
+	AgentSocket types.String `tfsdk:"agent_socket"`
+
+	// --- hardbox configuration ---
+	Profile            types.String `tfsdk:"profile"`
+	HardboxVersion     types.String `tfsdk:"hardbox_version"`
+	DryRun             types.Bool   `tfsdk:"dry_run"`
+	RollbackOnFailure  types.Bool   `tfsdk:"rollback_on_failure"`
+	ReportFormat       types.String `tfsdk:"report_format"`
+	FailOnCritical     types.Bool   `tfsdk:"fail_on_critical"`
+	FailOnHigh         types.Bool   `tfsdk:"fail_on_high"`
+
+	// --- Computed outputs ---
+	ReportContent  types.String `tfsdk:"report_content"`
+	AppliedAt      types.String `tfsdk:"applied_at"`
+	HardboxVersion_ types.String `tfsdk:"installed_version"`
+	Findings       types.Map    `tfsdk:"findings"`
+}
+
+func NewHardboxApplyResource() resource.Resource {
+	return &hardboxApplyResource{}
+}
+
+func (r *hardboxApplyResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_apply"
+}
+
+func (r *hardboxApplyResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		MarkdownDescription: `
+Provisions a remote Linux host with hardbox OS hardening.
+
+The resource:
+1. Connects to the host over SSH.
+2. Downloads the hardbox binary and verifies its SHA-256 checksum.
+3. Runs ` + "`hardbox apply`" + ` with the selected compliance profile.
+4. Captures the audit report and surfaces findings counts in Terraform state.
+5. On destroy, runs ` + "`hardbox rollback apply --last`" + ` to restore the pre-hardening snapshot.
+
+## Example
+
+` + "```hcl" + `
+resource "hardbox_apply" "web" {
+  host        = aws_instance.web.public_ip
+  user        = "ubuntu"
+  private_key = file("~/.ssh/id_rsa")
+  profile     = "cloud-aws"
+}
+` + "```",
+
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Computed:            true,
+				MarkdownDescription: "Unique identifier: `<host>:<profile>@<applied_at>`.",
+			},
+
+			// SSH connection
+			"host": schema.StringAttribute{
+				Required:            true,
+				MarkdownDescription: "IP address or hostname of the target Linux host.",
+			},
+			"port": schema.Int64Attribute{
+				Optional:            true,
+				Computed:            true,
+				MarkdownDescription: "SSH port (default: 22).",
+			},
+			"user": schema.StringAttribute{
+				Optional:            true,
+				Computed:            true,
+				Default:             stringdefault.StaticString("root"),
+				MarkdownDescription: "SSH username (default: `root`).",
+			},
+			"private_key": schema.StringAttribute{
+				Optional:            true,
+				Sensitive:           true,
+				MarkdownDescription: "PEM-encoded SSH private key. Mutually exclusive with `agent_socket`.",
+			},
+			"agent_socket": schema.StringAttribute{
+				Optional:            true,
+				MarkdownDescription: "Path to SSH agent socket (e.g. `$SSH_AUTH_SOCK`). Mutually exclusive with `private_key`.",
+			},
+
+			// hardbox options
+			"profile": schema.StringAttribute{
+				Required: true,
+				MarkdownDescription: `Compliance profile to apply. Any built-in profile is valid:
+` + "`cis-level1`" + `, ` + "`cis-level2`" + `, ` + "`pci-dss`" + `, ` + "`stig`" + `, ` + "`hipaa`" + `,
+` + "`iso27001`" + `, ` + "`cloud-aws`" + `, ` + "`cloud-gcp`" + `, ` + "`cloud-azure`" + `,
+` + "`production`" + `, ` + "`development`" + `.`,
+			},
+			"hardbox_version": schema.StringAttribute{
+				Optional:            true,
+				Computed:            true,
+				MarkdownDescription: "Override the provider-level `hardbox_version` for this resource.",
+			},
+			"dry_run": schema.BoolAttribute{
+				Optional:            true,
+				Computed:            true,
+				Default:             booldefault.StaticBool(false),
+				MarkdownDescription: "Pass `--dry-run` to hardbox — preview changes without applying (default: `false`).",
+			},
+			"rollback_on_failure": schema.BoolAttribute{
+				Optional:            true,
+				Computed:            true,
+				Default:             booldefault.StaticBool(true),
+				MarkdownDescription: "Run `hardbox rollback apply --last` when hardbox apply fails (default: `true`).",
+			},
+			"report_format": schema.StringAttribute{
+				Optional:            true,
+				Computed:            true,
+				Default:             stringdefault.StaticString("json"),
+				MarkdownDescription: "Audit report format: `json`, `html`, `text`, `markdown` (default: `json`).",
+			},
+			"fail_on_critical": schema.BoolAttribute{
+				Optional:            true,
+				Computed:            true,
+				Default:             booldefault.StaticBool(true),
+				MarkdownDescription: "Fail the Terraform apply if critical findings are detected (default: `true`).",
+			},
+			"fail_on_high": schema.BoolAttribute{
+				Optional:            true,
+				Computed:            true,
+				Default:             booldefault.StaticBool(true),
+				MarkdownDescription: "Fail the Terraform apply if high findings are detected (default: `true`).",
+			},
+
+			// Computed outputs
+			"report_content": schema.StringAttribute{
+				Computed:            true,
+				Sensitive:           false,
+				MarkdownDescription: "Contents of the hardbox audit report (JSON/HTML/text).",
+			},
+			"applied_at": schema.StringAttribute{
+				Computed:            true,
+				MarkdownDescription: "RFC3339 timestamp of when hardbox was last applied.",
+			},
+			"installed_version": schema.StringAttribute{
+				Computed:            true,
+				MarkdownDescription: "The hardbox version string installed on the target host.",
+			},
+			"findings": schema.MapAttribute{
+				Computed:            true,
+				ElementType:         types.StringType,
+				MarkdownDescription: "Map of finding severity counts: `{critical, high, medium, low, info}`.",
+			},
+		},
+	}
+}
+
+func (r *hardboxApplyResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	version, ok := req.ProviderData.(string)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected provider data type",
+			fmt.Sprintf("Expected string (hardbox version), got %T", req.ProviderData),
+		)
+		return
+	}
+	r.hardboxVersion = version
+}
+
+func (r *hardboxApplyResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var plan hardboxApplyModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	r.applyHardening(ctx, &plan, resp.Diagnostics.AddError)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+}
+
+func (r *hardboxApplyResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	// hardbox_apply is a provisioner-style resource; state reflects last apply.
+	// Read is a no-op — the resource is fully managed by Create/Update/Delete.
+	var state hardboxApplyModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
+
+func (r *hardboxApplyResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var plan hardboxApplyModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	r.applyHardening(ctx, &plan, resp.Diagnostics.AddError)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+}
+
+func (r *hardboxApplyResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var state hardboxApplyModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	tflog.Info(ctx, "Running hardbox rollback on destroy", map[string]any{
+		"host":    state.Host.ValueString(),
+		"profile": state.Profile.ValueString(),
+	})
+
+	conn, err := hardbox.NewSSHClient(hardbox.SSHConfig{
+		Host:        state.Host.ValueString(),
+		Port:        int(state.Port.ValueInt64()),
+		User:        state.User.ValueString(),
+		PrivateKey:  state.PrivateKey.ValueString(),
+		AgentSocket: state.AgentSocket.ValueString(),
+	})
+	if err != nil {
+		resp.Diagnostics.AddWarning(
+			"Rollback skipped — SSH connection failed",
+			fmt.Sprintf("Could not connect to %s: %s", state.Host.ValueString(), err),
+		)
+		return
+	}
+	defer conn.Close()
+
+	out, err := conn.Run("hardbox rollback apply --last --non-interactive")
+	if err != nil {
+		resp.Diagnostics.AddWarning(
+			"Rollback command failed",
+			fmt.Sprintf("hardbox rollback apply --last failed: %s\nOutput: %s", err, out),
+		)
+	} else {
+		tflog.Info(ctx, "Rollback completed", map[string]any{"output": out})
+	}
+}
+
+func (r *hardboxApplyResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resp.Diagnostics.AddError(
+		"Import not supported",
+		"hardbox_apply is a provisioner resource and cannot be imported. Remove it from state with `terraform state rm` and re-apply.",
+	)
+}
+
+// applyHardening executes the full install + apply flow on the remote host.
+func (r *hardboxApplyResource) applyHardening(
+	ctx context.Context,
+	m *hardboxApplyModel,
+	addError func(summary, detail string),
+) {
+	version := r.hardboxVersion
+	if !m.HardboxVersion.IsNull() && !m.HardboxVersion.IsUnknown() && m.HardboxVersion.ValueString() != "" {
+		version = m.HardboxVersion.ValueString()
+	}
+
+	tflog.Info(ctx, "Connecting to target host", map[string]any{
+		"host":    m.Host.ValueString(),
+		"profile": m.Profile.ValueString(),
+		"version": version,
+	})
+
+	conn, err := hardbox.NewSSHClient(hardbox.SSHConfig{
+		Host:        m.Host.ValueString(),
+		Port:        int(m.Port.ValueInt64()),
+		User:        m.User.ValueString(),
+		PrivateKey:  m.PrivateKey.ValueString(),
+		AgentSocket: m.AgentSocket.ValueString(),
+	})
+	if err != nil {
+		addError("SSH connection failed", fmt.Sprintf("Cannot connect to %s: %s", m.Host.ValueString(), err))
+		return
+	}
+	defer conn.Close()
+
+	// Step 1: Install hardbox with checksum verification.
+	installedVersion, err := hardbox.Install(ctx, conn, version)
+	if err != nil {
+		addError("hardbox installation failed", err.Error())
+		return
+	}
+	tflog.Info(ctx, "hardbox installed", map[string]any{"version": installedVersion})
+
+	// Step 2: Apply hardening profile.
+	reportPath := fmt.Sprintf("/var/lib/hardbox/reports/tf-%d.%s",
+		time.Now().Unix(), m.ReportFormat.ValueString())
+
+	applyCmd := strings.Join([]string{
+		"hardbox apply",
+		"--profile", m.Profile.ValueString(),
+		"--format", m.ReportFormat.ValueString(),
+		"--output", reportPath,
+		"--non-interactive",
+	}, " ")
+	if m.DryRun.ValueBool() {
+		applyCmd += " --dry-run"
+	}
+
+	applyOut, applyErr := conn.Run(applyCmd)
+	tflog.Debug(ctx, "hardbox apply output", map[string]any{"output": applyOut})
+
+	if applyErr != nil {
+		if m.RollbackOnFailure.ValueBool() {
+			tflog.Warn(ctx, "Apply failed — running rollback", map[string]any{"error": applyErr.Error()})
+			rbOut, rbErr := conn.Run("hardbox rollback apply --last --non-interactive")
+			if rbErr != nil {
+				addError("hardbox apply + rollback failed",
+					fmt.Sprintf("Apply error: %s\nRollback error: %s\nRollback output: %s", applyErr, rbErr, rbOut))
+				return
+			}
+			tflog.Info(ctx, "Rollback completed", map[string]any{"output": rbOut})
+		}
+		addError("hardbox apply failed", fmt.Sprintf("%s\nOutput: %s", applyErr, applyOut))
+		return
+	}
+
+	// Step 3: Fetch report content.
+	reportContent, err := conn.ReadFile(reportPath)
+	if err != nil {
+		tflog.Warn(ctx, "Could not read report file", map[string]any{"path": reportPath, "error": err.Error()})
+		reportContent = ""
+	}
+
+	// Step 4: Parse findings from JSON report (best-effort).
+	findings := hardbox.ParseFindings(reportContent, m.ReportFormat.ValueString())
+
+	// Step 5: Check thresholds.
+	if m.FailOnCritical.ValueBool() && findings["critical"] != "0" && findings["critical"] != "" {
+		addError("hardbox: critical findings detected",
+			fmt.Sprintf("Profile %s reported %s critical findings. Review the report.", m.Profile.ValueString(), findings["critical"]))
+		return
+	}
+	if m.FailOnHigh.ValueBool() && findings["high"] != "0" && findings["high"] != "" {
+		addError("hardbox: high findings detected",
+			fmt.Sprintf("Profile %s reported %s high findings. Review the report.", m.Profile.ValueString(), findings["high"]))
+		return
+	}
+
+	// Step 6: Populate state.
+	now := time.Now().UTC().Format(time.RFC3339)
+	m.ID = types.StringValue(fmt.Sprintf("%s:%s@%s", m.Host.ValueString(), m.Profile.ValueString(), now))
+	m.AppliedAt = types.StringValue(now)
+	m.HardboxVersion_ = types.StringValue(installedVersion)
+	m.ReportContent = types.StringValue(reportContent)
+	m.HardboxVersion = types.StringValue(version)
+
+	findingsMap := make(map[string]attr.Value, len(findings))
+	for k, v := range findings {
+		findingsMap[k] = types.StringValue(v)
+	}
+	m.Findings, _ = types.MapValue(types.StringType, findingsMap)
+}

--- a/terraform-provider/internal/provider/resource_hardbox_apply.go
+++ b/terraform-provider/internal/provider/resource_hardbox_apply.go
@@ -36,6 +36,7 @@ type hardboxApplyModel struct {
 	User        types.String `tfsdk:"user"`
 	PrivateKey  types.String `tfsdk:"private_key"`
 	AgentSocket types.String `tfsdk:"agent_socket"`
+	HostKey     types.String `tfsdk:"host_key"`
 
 	// --- hardbox configuration ---
 	Profile            types.String `tfsdk:"profile"`
@@ -114,6 +115,14 @@ resource "hardbox_apply" "web" {
 			"agent_socket": schema.StringAttribute{
 				Optional:            true,
 				MarkdownDescription: "Path to SSH agent socket (e.g. `$SSH_AUTH_SOCK`). Mutually exclusive with `private_key`.",
+			},
+			"host_key": schema.StringAttribute{
+				Optional:  true,
+				Sensitive: false,
+				MarkdownDescription: `Base64-encoded SSH public host key of the target server.
+Used to verify the server identity and prevent MITM attacks.
+Obtain with: ` + "`ssh-keyscan -t ed25519 <host> | awk '{print $3}'`" + `
+When omitted, the system ` + "`~/.ssh/known_hosts`" + ` file is used for verification.`,
 			},
 
 			// hardbox options
@@ -254,6 +263,7 @@ func (r *hardboxApplyResource) Delete(ctx context.Context, req resource.DeleteRe
 		User:        state.User.ValueString(),
 		PrivateKey:  state.PrivateKey.ValueString(),
 		AgentSocket: state.AgentSocket.ValueString(),
+		HostKey:     state.HostKey.ValueString(),
 	})
 	if err != nil {
 		resp.Diagnostics.AddWarning(
@@ -305,6 +315,7 @@ func (r *hardboxApplyResource) applyHardening(
 		User:        m.User.ValueString(),
 		PrivateKey:  m.PrivateKey.ValueString(),
 		AgentSocket: m.AgentSocket.ValueString(),
+		HostKey:     m.HostKey.ValueString(),
 	})
 	if err != nil {
 		addError("SSH connection failed", fmt.Sprintf("Cannot connect to %s: %s", m.Host.ValueString(), err))

--- a/terraform-provider/main.go
+++ b/terraform-provider/main.go
@@ -1,0 +1,33 @@
+// Package main is the entrypoint for the hardbox Terraform provider.
+// Build with: go build -o terraform-provider-hardbox .
+package main
+
+import (
+	"context"
+	"flag"
+	"log"
+
+	"github.com/hashicorp/terraform-plugin-framework/providerserver"
+	"github.com/jackby03/terraform-provider-hardbox/internal/provider"
+)
+
+// version is set at build time via ldflags:
+//
+//	-ldflags "-X main.version=v0.3.0"
+var version = "dev"
+
+func main() {
+	var debug bool
+	flag.BoolVar(&debug, "debug", false, "Enable provider debug mode")
+	flag.Parse()
+
+	opts := providerserver.ServeOpts{
+		Address: "registry.terraform.io/jackby03/hardbox",
+		Debug:   debug,
+	}
+
+	err := providerserver.Serve(context.Background(), provider.New(version), opts)
+	if err != nil {
+		log.Fatal(err)
+	}
+}


### PR DESCRIPTION
## Summary

Closes #110

Adds `terraform-provider/` — a Terraform Registry-compatible provider (`jackby03/hardbox`) that provisions OS hardening on remote Linux hosts as part of `terraform apply`, completing the last P2 item from the v0.3 roadmap (#112).

## Resource: `hardbox_apply`

The provider exposes a single resource that:

1. Connects to the target host over SSH (private key or agent socket)
2. Downloads the hardbox binary and verifies its **SHA-256 checksum** before installing
3. Skips re-install if the target version is already present
4. Runs `hardbox apply --non-interactive` with the selected profile
5. On failure: automatically runs `hardbox rollback apply --last` (configurable)
6. On `terraform destroy`: runs `hardbox rollback apply --last` to restore pre-hardening snapshot
7. Parses the JSON audit report and surfaces **finding severity counts** in Terraform state

## Files changed

| File | Change |
|---|---|
| `terraform-provider/main.go` | Provider entrypoint (Terraform Plugin Framework v6) |
| `terraform-provider/internal/provider/provider.go` | Provider schema — `hardbox_version` config |
| `terraform-provider/internal/provider/resource_hardbox_apply.go` | `hardbox_apply` resource — Create/Read/Update/Delete |
| `terraform-provider/internal/hardbox/ssh.go` | SSH client (private key + agent socket) |
| `terraform-provider/internal/hardbox/install.go` | Binary download, checksum verification, install |
| `terraform-provider/examples/aws/main.tf` + `variables.tf` | EC2 + `cloud-aws` profile example |
| `terraform-provider/examples/gcp/main.tf` | Compute Engine + `cloud-gcp` profile example |
| `terraform-provider/examples/azure/main.tf` | Azure VM + `cloud-azure` profile example |
| `docs/TERRAFORM.md` | Provider docs: schema reference, examples, CI/CD, build instructions |
| `CHANGELOG.md` | [Unreleased] Added entries |

## Computed state attributes

```hcl
output "findings" {
  value = hardbox_apply.web.findings
  # → { critical = "0", high = "2", medium = "5", low = "12", info = "3" }
}
```

## Test plan

- [ ] `terraform init` resolves provider from local build
- [ ] `hardbox_apply` Create: binary installed with correct checksum
- [ ] `hardbox_apply` Create: report captured in `report_content`
- [ ] `hardbox_apply` Create: findings map populated from JSON report
- [ ] `hardbox_apply` Delete: `hardbox rollback apply --last` executed on destroy
- [ ] Checksum mismatch causes resource creation failure (non-zero exit)
- [ ] `fail_on_critical = true` fails apply when critical findings present
- [ ] `dry_run = true` passes `--dry-run` to hardbox (no state changes on host)
- [ ] AWS, GCP, Azure example configurations are valid (`terraform validate`)

https://claude.ai/code/session_016UiLjmeSDKyMW1yvK4SVaQ