### PR TITLE
feat(sdk): Plugin SDK — custom hardening module interface (#123)

### DIFF
--- a/docs/PLUGIN-SDK.md
+++ b/docs/PLUGIN-SDK.md
@@ -1,0 +1,266 @@
+# hardbox Plugin SDK
+
+The Plugin SDK lets you write custom hardening modules and load them into hardbox at runtime — no forking or recompiling the core required.
+
+## Prerequisites
+
+- Go 1.22+
+- Linux, macOS, or FreeBSD (Go's `plugin` package is not supported on Windows)
+- CGO enabled (required by `go build -buildmode=plugin`)
+- Your plugin must be built with the **same Go version and the same hardbox source tree** as the running binary
+
+## Quickstart
+
+### 1. Create your plugin
+
+Create a directory for your plugin and write a Go file with `package main`:
+
+```go
+package main
+
+import (
+    "context"
+    "fmt"
+    "os"
+
+    "github.com/hardbox-io/hardbox/internal/sdk"
+)
+
+type myModule struct{}
+
+func (m *myModule) Name() string    { return "my-module" }
+func (m *myModule) Version() string { return "1.0.0" }
+
+func (m *myModule) Audit(_ context.Context, cfg sdk.ModuleConfig) ([]sdk.Finding, error) {
+    check := sdk.Check{
+        ID:       "MY-001",
+        Title:    "My custom check",
+        Severity: sdk.SeverityMedium,
+    }
+
+    // inspect the live system...
+    ok := true // replace with real check logic
+
+    if !ok {
+        return []sdk.Finding{{
+            Check:  check,
+            Status: sdk.StatusNonCompliant,
+            Detail: "condition not met",
+        }}, nil
+    }
+    return []sdk.Finding{{Check: check, Status: sdk.StatusCompliant}}, nil
+}
+
+func (m *myModule) Plan(_ context.Context, cfg sdk.ModuleConfig) ([]sdk.Change, error) {
+    // return nil, nil if Audit already passed
+    return []sdk.Change{{
+        Description: "Fix my condition",
+        Apply:       func() error { /* apply fix */ return nil },
+        Revert:      func() error { /* undo fix */ return nil },
+    }}, nil
+}
+
+// New is the mandatory entry-point symbol. hardbox calls this to instantiate
+// your module. It must be exported and match this exact signature.
+func New() sdk.Module { return &myModule{} }
+
+// main is required so the file compiles normally. It is ignored at plugin load time.
+func main() {}
+```
+
+### 2. Build the plugin
+
+```bash
+go build -buildmode=plugin -o my-module.so .
+```
+
+> **Important:** Build the plugin from within the hardbox source tree (or with the same module at the same version) to ensure type compatibility at load time.
+
+### 3. Install the plugin
+
+```bash
+# Copies my-module.so to /etc/hardbox/plugins/ (requires write access)
+hardbox plugin install my-module.so
+```
+
+Or copy manually:
+
+```bash
+sudo cp my-module.so /etc/hardbox/plugins/
+```
+
+### 4. Verify the plugin loaded
+
+```bash
+hardbox plugin list
+```
+
+Output:
+```
+NAME                     VERSION    PATH
+my-module                1.0.0      /etc/hardbox/plugins/my-module.so
+```
+
+---
+
+## SDK Reference
+
+All types below are imported from `github.com/hardbox-io/hardbox/internal/sdk`.
+
+### `Module` interface
+
+```go
+type Module interface {
+    Name() string
+    Version() string
+    Audit(ctx context.Context, cfg ModuleConfig) ([]Finding, error)
+    Plan(ctx context.Context, cfg ModuleConfig) ([]Change, error)
+}
+```
+
+| Method | Description |
+|--------|-------------|
+| `Name()` | Unique module identifier, e.g. `"my-module"`. Must not collide with built-in module names. |
+| `Version()` | Semver string, e.g. `"1.0.0"`. Used for display only. |
+| `Audit()` | Read-only inspection of the live system. Must not modify system state. |
+| `Plan()` | Returns reversible changes needed to reach compliance. Changes are not executed here. |
+
+### `Finding`
+
+```go
+type Finding struct {
+    Check   Check
+    Status  Status  // StatusCompliant | StatusNonCompliant | StatusManual | StatusSkipped | StatusError
+    Current string  // observed value
+    Target  string  // desired value
+    Detail  string  // human-readable explanation
+}
+```
+
+### `Check`
+
+```go
+type Check struct {
+    ID          string
+    Title       string
+    Description string
+    Remediation string
+    Severity    Severity       // SeverityCritical | High | Medium | Low | Info
+    Compliance  []ComplianceRef
+}
+```
+
+### `ComplianceRef`
+
+```go
+type ComplianceRef struct {
+    Framework string // "CIS", "NIST", "STIG", "PCI-DSS", "HIPAA", "ISO27001"
+    Control   string // e.g. "5.2.8", "AC-6", "V-238218"
+}
+```
+
+### `Change`
+
+```go
+type Change struct {
+    Description  string
+    DryRunOutput string   // shown with --dry-run
+    Apply        func() error
+    Revert       func() error
+}
+```
+
+`Apply` and `Revert` must be paired: if `Apply` succeeds, `Revert` must be able to undo it. The engine takes a snapshot before calling `Apply` and calls `Revert` automatically if a later step fails.
+
+### `ModuleConfig`
+
+```go
+type ModuleConfig map[string]any
+```
+
+Per-module settings from the active profile. To expose configuration for your module, add a section to the YAML profile:
+
+```yaml
+modules:
+  my-module:
+    enabled: true
+    my_setting: "value"
+```
+
+Then read it in `Audit` / `Plan`:
+
+```go
+func (m *myModule) Audit(_ context.Context, cfg sdk.ModuleConfig) ([]sdk.Finding, error) {
+    val, _ := cfg["my_setting"].(string)
+    // ...
+}
+```
+
+---
+
+## Configuration
+
+| Field | Default | Description |
+|-------|---------|-------------|
+| `plugin_dir` | `/etc/hardbox/plugins` | Directory scanned for `.so` files at startup |
+
+Override via config file or environment variable:
+
+```yaml
+# /etc/hardbox/config.yaml
+plugin_dir: /opt/hardbox/plugins
+```
+
+```bash
+export HARDBOX_PLUGIN_DIR=/opt/hardbox/plugins
+```
+
+Set `plugin_dir: ""` to disable plugin loading entirely.
+
+---
+
+## CLI Reference
+
+### `hardbox plugin list`
+
+Lists all plugins currently loaded from the plugin directory.
+
+```
+NAME                     VERSION    PATH
+custom-tmp-sticky        1.0.0      /etc/hardbox/plugins/custom-tmp-check.so
+```
+
+### `hardbox plugin install <plugin.so>`
+
+Copies a `.so` file into the plugin directory. Creates the directory if it does not exist.
+
+```bash
+hardbox plugin install /path/to/my-module.so
+# Plugin installed: /etc/hardbox/plugins/my-module.so
+```
+
+---
+
+## Platform support
+
+| Platform | Plugin loading |
+|----------|---------------|
+| Linux    | Supported |
+| macOS    | Supported |
+| FreeBSD  | Supported |
+| Windows  | Not supported (hardbox targets Linux servers) |
+
+---
+
+## Example plugin
+
+A fully working example is available at [`examples/plugin-custom-check/`](../examples/plugin-custom-check/plugin.go). It checks whether `/tmp` has the sticky bit set — a real CIS benchmark requirement.
+
+Build it:
+
+```bash
+cd examples/plugin-custom-check
+go build -buildmode=plugin -o custom-tmp-check.so .
+hardbox plugin install custom-tmp-check.so
+hardbox audit
+```

--- a/examples/plugin-custom-check/plugin.go
+++ b/examples/plugin-custom-check/plugin.go
@@ -1,0 +1,103 @@
+// Package main is an example hardbox plugin that checks whether the /tmp
+// directory has the sticky bit set (permissions 1777). This is a real
+// hardening requirement: without the sticky bit, any user can delete files
+// owned by others inside /tmp.
+//
+// # Build
+//
+//	go build -buildmode=plugin -o custom-tmp-check.so .
+//
+// # Install
+//
+//	hardbox plugin install custom-tmp-check.so
+//
+// # Verify
+//
+//	hardbox plugin list
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/hardbox-io/hardbox/internal/sdk"
+)
+
+// tmpStickyModule checks that /tmp has the sticky bit set.
+type tmpStickyModule struct{}
+
+func (m *tmpStickyModule) Name() string    { return "custom-tmp-sticky" }
+func (m *tmpStickyModule) Version() string { return "1.0.0" }
+
+func (m *tmpStickyModule) Audit(_ context.Context, _ sdk.ModuleConfig) ([]sdk.Finding, error) {
+	check := sdk.Check{
+		ID:          "CUSTOM-001",
+		Title:       "/tmp sticky bit",
+		Description: "The /tmp directory must have the sticky bit set (mode 1777) so that users cannot delete each other's files.",
+		Remediation: "Run: chmod +t /tmp",
+		Severity:    sdk.SeverityMedium,
+		Compliance: []sdk.ComplianceRef{
+			{Framework: "CIS", Control: "1.1.2"},
+		},
+	}
+
+	info, err := os.Stat("/tmp")
+	if err != nil {
+		return []sdk.Finding{{
+			Check:  check,
+			Status: sdk.StatusError,
+			Detail: fmt.Sprintf("could not stat /tmp: %v", err),
+		}}, nil
+	}
+
+	mode := info.Mode()
+	if mode&os.ModeSticky == 0 {
+		return []sdk.Finding{{
+			Check:   check,
+			Status:  sdk.StatusNonCompliant,
+			Current: fmt.Sprintf("%04o", mode.Perm()),
+			Target:  "1777",
+			Detail:  "/tmp does not have the sticky bit set",
+		}}, nil
+	}
+
+	return []sdk.Finding{{
+		Check:   check,
+		Status:  sdk.StatusCompliant,
+		Current: fmt.Sprintf("%04o", mode.Perm()|os.ModeSticky),
+		Target:  "1777",
+	}}, nil
+}
+
+func (m *tmpStickyModule) Plan(_ context.Context, _ sdk.ModuleConfig) ([]sdk.Change, error) {
+	info, err := os.Stat("/tmp")
+	if err != nil {
+		return nil, fmt.Errorf("stat /tmp: %w", err)
+	}
+
+	if info.Mode()&os.ModeSticky != 0 {
+		return nil, nil // already compliant
+	}
+
+	return []sdk.Change{{
+		Description:  "Set sticky bit on /tmp (chmod +t /tmp)",
+		DryRunOutput: "chmod 1777 /tmp",
+		Apply: func() error {
+			return os.Chmod("/tmp", 0o1777)
+		},
+		Revert: func() error {
+			return os.Chmod("/tmp", info.Mode().Perm())
+		},
+	}}, nil
+}
+
+// New is the entry-point symbol loaded by hardbox.
+// It must be exported and have the signature: func New() sdk.Module
+func New() sdk.Module {
+	return &tmpStickyModule{}
+}
+
+// main is required so the file compiles with `go build` in addition to
+// `go build -buildmode=plugin`. It is not called when loaded as a plugin.
+func main() {}

--- a/internal/cli/plugin.go
+++ b/internal/cli/plugin.go
@@ -1,0 +1,106 @@
+package cli
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+
+	"github.com/hardbox-io/hardbox/internal/config"
+	"github.com/hardbox-io/hardbox/internal/engine"
+)
+
+func newPluginCmd(gf *globalFlags) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "plugin",
+		Short: "Manage hardbox plugins",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cmd.Help()
+		},
+	}
+	cmd.AddCommand(
+		newPluginListCmd(gf),
+		newPluginInstallCmd(gf),
+	)
+	return cmd
+}
+
+func newPluginListCmd(gf *globalFlags) *cobra.Command {
+	return &cobra.Command{
+		Use:   "list",
+		Short: "List loaded plugins",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cfg, err := config.Load(gf.cfgFile, gf.profile)
+			if err != nil {
+				return err
+			}
+
+			e := engine.New(cfg)
+			plugins := e.ListPlugins()
+
+			if len(plugins) == 0 {
+				fmt.Fprintf(cmd.OutOrStdout(), "No plugins loaded (plugin_dir: %s)\n", cfg.PluginDir)
+				return nil
+			}
+
+			fmt.Fprintf(cmd.OutOrStdout(), "%-24s %-10s %s\n", "NAME", "VERSION", "PATH")
+			for _, p := range plugins {
+				fmt.Fprintf(cmd.OutOrStdout(), "%-24s %-10s %s\n", p.Name, p.Version, p.Path)
+			}
+			return nil
+		},
+	}
+}
+
+func newPluginInstallCmd(gf *globalFlags) *cobra.Command {
+	return &cobra.Command{
+		Use:   "install <plugin.so>",
+		Short: "Install a plugin .so into the plugin directory",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			src := args[0]
+
+			if filepath.Ext(src) != ".so" {
+				return fmt.Errorf("plugin file must have a .so extension")
+			}
+
+			cfg, err := config.Load(gf.cfgFile, gf.profile)
+			if err != nil {
+				return err
+			}
+
+			if err := os.MkdirAll(cfg.PluginDir, 0o755); err != nil {
+				return fmt.Errorf("creating plugin directory %s: %w", cfg.PluginDir, err)
+			}
+
+			dst := filepath.Join(cfg.PluginDir, filepath.Base(src))
+			if err := copyFile(src, dst); err != nil {
+				return fmt.Errorf("installing plugin: %w", err)
+			}
+
+			fmt.Fprintf(cmd.OutOrStdout(), "Plugin installed: %s\n", dst)
+			return nil
+		},
+	}
+}
+
+func copyFile(src, dst string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+
+	out, err := os.OpenFile(dst, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o644)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+
+	if _, err := io.Copy(out, in); err != nil {
+		return err
+	}
+	return out.Close()
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -46,6 +46,7 @@ func newRootCmd(version string) *cobra.Command {
 		newRollbackCmd(),
 		newDiffCmd(),
 		newFleetCmd(gf),
+		newPluginCmd(gf),
 	)
 
 	return root

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -21,6 +21,10 @@ type Config struct {
 	DryRun         bool
 	NonInteractive bool
 
+	// PluginDir is the directory scanned for .so plugin files at startup.
+	// Defaults to /etc/hardbox/plugins. Set to "" to disable plugin loading.
+	PluginDir string `mapstructure:"plugin_dir"`
+
 	Modules map[string]ModuleConfig `mapstructure:"modules"`
 	Report  ReportConfig            `mapstructure:"report"`
 	Audit   AuditConfig             `mapstructure:"audit"`
@@ -120,4 +124,5 @@ func setDefaults(v *viper.Viper) {
 	v.SetDefault("report.include_evidence", true)
 	v.SetDefault("audit.fail_on_critical", true)
 	v.SetDefault("audit.fail_on_high", false)
+	v.SetDefault("plugin_dir", "/etc/hardbox/plugins")
 }

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -13,18 +13,29 @@ import (
 	"github.com/hardbox-io/hardbox/internal/distro"
 	"github.com/hardbox-io/hardbox/internal/modules"
 	"github.com/hardbox-io/hardbox/internal/report"
+	"github.com/hardbox-io/hardbox/internal/sdk"
 )
 
 // Engine orchestrates the plan → snapshot → execute → verify → report lifecycle.
 type Engine struct {
 	cfg        *config.Config
 	modules    []modules.Module
+	plugins    []sdk.PluginEntry
 	DistroInfo *distro.Info
+}
+
+// PluginInfo describes a plugin module loaded from a .so file.
+type PluginInfo struct {
+	Name    string
+	Version string
+	Path    string
 }
 
 // New creates an Engine with all built-in modules registered.
 // It calls distro.Detect() at startup and logs the result; a detection failure
 // is non-fatal — the engine continues without distro information.
+// Plugins are loaded from cfg.PluginDir; plugin load errors are logged as
+// warnings and do not prevent the engine from starting.
 func New(cfg *config.Config) *Engine {
 	e := &Engine{
 		cfg:     cfg,
@@ -41,6 +52,22 @@ func New(cfg *config.Config) *Engine {
 			Str("family", string(info.Family)).
 			Str("pretty_name", info.PrettyName).
 			Msg("distro detected")
+	}
+
+	if cfg.PluginDir != "" {
+		plugins, err := sdk.LoadPlugins(cfg.PluginDir)
+		if err != nil {
+			log.Warn().Err(err).Str("plugin_dir", cfg.PluginDir).Msg("plugin load warning")
+		}
+		for _, p := range plugins {
+			e.modules = append(e.modules, p.Module)
+			e.plugins = append(e.plugins, p)
+			log.Info().
+				Str("plugin", p.Module.Name()).
+				Str("version", p.Module.Version()).
+				Str("path", p.Path).
+				Msg("plugin loaded")
+		}
 	}
 
 	return e
@@ -120,9 +147,22 @@ func (e *Engine) Apply(ctx context.Context) error {
 	return nil
 }
 
-// GetModules returns the list of registered modules.
+// GetModules returns the list of registered modules (built-in + plugins).
 func (e *Engine) GetModules() []modules.Module {
 	return e.modules
+}
+
+// ListPlugins returns metadata for every plugin loaded from the plugin directory.
+func (e *Engine) ListPlugins() []PluginInfo {
+	infos := make([]PluginInfo, 0, len(e.plugins))
+	for _, p := range e.plugins {
+		infos = append(infos, PluginInfo{
+			Name:    p.Module.Name(),
+			Version: p.Module.Version(),
+			Path:    p.Path,
+		})
+	}
+	return infos
 }
 
 // AuditModule runs the audit for the named module and returns its findings.

--- a/internal/sdk/loader.go
+++ b/internal/sdk/loader.go
@@ -1,0 +1,72 @@
+//go:build linux || darwin || freebsd
+
+package sdk
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"plugin"
+
+	"github.com/hardbox-io/hardbox/internal/modules"
+)
+
+// LoadPlugins loads all .so files from dir and returns the modules they export.
+// Each .so must export a symbol named "New" of type func() sdk.Module.
+//
+// If dir does not exist, LoadPlugins returns nil, nil (no plugins is not an error).
+// Errors from individual plugins are collected and returned as a single combined
+// error after all files have been attempted, so a bad plugin does not block others.
+func LoadPlugins(dir string) ([]PluginEntry, error) {
+	entries, err := os.ReadDir(dir)
+	if os.IsNotExist(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("reading plugin dir %s: %w", dir, err)
+	}
+
+	var loaded []PluginEntry
+	var loadErrs []string
+
+	for _, e := range entries {
+		if e.IsDir() || filepath.Ext(e.Name()) != ".so" {
+			continue
+		}
+		path := filepath.Join(dir, e.Name())
+		m, err := loadPlugin(path)
+		if err != nil {
+			loadErrs = append(loadErrs, fmt.Sprintf("%s: %v", e.Name(), err))
+			continue
+		}
+		loaded = append(loaded, PluginEntry{Path: path, Module: m})
+	}
+
+	if len(loadErrs) > 0 {
+		combined := ""
+		for _, e := range loadErrs {
+			combined += "\n  " + e
+		}
+		return loaded, fmt.Errorf("one or more plugins failed to load:%s", combined)
+	}
+	return loaded, nil
+}
+
+func loadPlugin(path string) (modules.Module, error) {
+	p, err := plugin.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("opening plugin: %w", err)
+	}
+
+	sym, err := p.Lookup(NewSymbol)
+	if err != nil {
+		return nil, fmt.Errorf("symbol %q not found — plugin must export: func %s() sdk.Module", NewSymbol, NewSymbol)
+	}
+
+	newFn, ok := sym.(func() Module)
+	if !ok {
+		return nil, fmt.Errorf("symbol %q has wrong type — expected func() sdk.Module, got %T", NewSymbol, sym)
+	}
+
+	return newFn(), nil
+}

--- a/internal/sdk/loader_unsupported.go
+++ b/internal/sdk/loader_unsupported.go
@@ -1,0 +1,12 @@
+//go:build !linux && !darwin && !freebsd
+
+package sdk
+
+import "fmt"
+
+// LoadPlugins is not supported on this platform. Go's plugin package requires
+// Linux, macOS, or FreeBSD. This stub returns an informational error so the
+// engine can log a warning and continue without plugins.
+func LoadPlugins(_ string) ([]PluginEntry, error) {
+	return nil, fmt.Errorf("plugin loading is not supported on this platform (requires Linux, macOS, or FreeBSD)")
+}

--- a/internal/sdk/module.go
+++ b/internal/sdk/module.go
@@ -1,0 +1,85 @@
+// Package sdk exposes the stable public interface for hardbox plugin authors.
+// Import this package to implement a custom hardening module that can be loaded
+// into hardbox at runtime without forking the core.
+//
+// # Quickstart
+//
+// Create a Go file in its own directory with package main:
+//
+//	package main
+//
+//	import (
+//	    "context"
+//	    "github.com/hardbox-io/hardbox/internal/sdk"
+//	)
+//
+//	type myModule struct{}
+//
+//	func (m *myModule) Name() string    { return "my-module" }
+//	func (m *myModule) Version() string { return "1.0.0" }
+//
+//	func (m *myModule) Audit(ctx context.Context, cfg sdk.ModuleConfig) ([]sdk.Finding, error) {
+//	    // inspect the system and return findings
+//	    return nil, nil
+//	}
+//
+//	func (m *myModule) Plan(ctx context.Context, cfg sdk.ModuleConfig) ([]sdk.Change, error) {
+//	    // return reversible changes needed to reach compliance
+//	    return nil, nil
+//	}
+//
+//	// New is the entry-point symbol loaded by hardbox. It must be exported.
+//	func New() sdk.Module { return &myModule{} }
+//
+//	func main() {} // required by go build; ignored at plugin load time
+//
+// Build and install the plugin:
+//
+//	go build -buildmode=plugin -o my-module.so .
+//	hardbox plugin install my-module.so
+package sdk
+
+import "github.com/hardbox-io/hardbox/internal/modules"
+
+// Module is the interface every hardbox hardening module must implement.
+// It is identical to internal/modules.Module and guaranteed stable.
+type Module = modules.Module
+
+// Re-exported types so plugin authors only need to import this package.
+type (
+	Finding       = modules.Finding
+	Check         = modules.Check
+	Change        = modules.Change
+	ModuleConfig  = modules.ModuleConfig
+	ComplianceRef = modules.ComplianceRef
+	Severity      = modules.Severity
+	Status        = modules.Status
+)
+
+// Severity constants.
+const (
+	SeverityCritical = modules.SeverityCritical
+	SeverityHigh     = modules.SeverityHigh
+	SeverityMedium   = modules.SeverityMedium
+	SeverityLow      = modules.SeverityLow
+	SeverityInfo     = modules.SeverityInfo
+)
+
+// Status constants.
+const (
+	StatusCompliant    = modules.StatusCompliant
+	StatusNonCompliant = modules.StatusNonCompliant
+	StatusManual       = modules.StatusManual
+	StatusSkipped      = modules.StatusSkipped
+	StatusError        = modules.StatusError
+)
+
+// NewSymbol is the name of the exported constructor that every plugin .so must
+// provide: func New() sdk.Module
+const NewSymbol = "New"
+
+// PluginEntry holds a loaded plugin module together with the path it was loaded from.
+type PluginEntry struct {
+	Path   string
+	Module modules.Module
+}


### PR DESCRIPTION
Add internal/sdk package with stable public types, a .so plugin loader (Linux/macOS/FreeBSD via Go plugin package), engine integration that loads plugins from plugin_dir at startup, hardbox plugin list/install CLI commands, a working example plugin (custom-tmp-sticky), and docs/PLUGIN-SDK.md.