### PR TITLE
fix(report): escape CSS width:100% in fmt.Fprintf format string

### DIFF
--- a/internal/report/render_diff_html.go
+++ b/internal/report/render_diff_html.go
@@ -52,7 +52,7 @@ func renderDiffHTML(d *DiffReport, w io.Writer) error {
   .badge.blue{border-color:var(--blue);color:var(--blue)}
   .section{margin-bottom:2rem}
   .section-title{font-size:1rem;font-weight:600;margin-bottom:.75rem;display:flex;align-items:center;gap:.5rem}
-  table{width:100%;border-collapse:collapse;background:var(--card);border-radius:.5rem;overflow:hidden;border:1px solid var(--border)}
+  table{width:100%%;border-collapse:collapse;background:var(--card);border-radius:.5rem;overflow:hidden;border:1px solid var(--border)}
   th{background:#0f172a;padding:.6rem 1rem;text-align:left;font-size:.75rem;text-transform:uppercase;color:var(--muted);letter-spacing:.05em}
   td{padding:.6rem 1rem;border-top:1px solid var(--border);vertical-align:top}
   .sev-critical{color:#f87171}.sev-high{color:#fb923c}.sev-medium{color:var(--yellow)}.sev-low{color:var(--blue)}.sev-info{color:var(--muted)}


### PR DESCRIPTION
## Summary

- `render_diff_html.go` builds the HTML output by passing a raw string literal (containing CSS + HTML) as a format string to `fmt.Fprintf` via a local `p()` helper
- The CSS rule `width:100%;` caused `go vet` to flag `%;` as an unknown format verb
- Fix: escape `%` → `%%` so `fmt.Fprintf` emits a literal `%` in the rendered output

## Root cause

```go
p := func(s string, args ...any) error {
    _, err := fmt.Fprintf(w, s, args...)   // s is the format string
    return err
}

// Later — width:100% in CSS is treated as a format verb:
p(`... table{width:100%;...} ...`)   // %; = unknown verb
```

## Fix

```diff
- table{width:100%;border-collapse:collapse;...}
+ table{width:100%%;border-collapse:collapse;...}
```

`%%` → `%` in the rendered HTML. No behaviour change.

## Test plan

- [x] `go vet ./internal/report/...` — clean
- [x] `go test ./...` — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)