### PR TITLE
feat(serve): hardbox serve — lightweight web dashboard

### DIFF
--- a/docs/SERVE.md
+++ b/docs/SERVE.md
@@ -1,0 +1,59 @@
+# hardbox serve — Web Dashboard
+
+`hardbox serve` starts a local, read-only HTTP dashboard for browsing audit reports, inspecting findings, and comparing reports side by side.
+
+## Usage
+
+```bash
+hardbox serve [flags]
+```
+
+### Flags
+
+| Flag | Default | Description |
+|---|---|---|
+| `--reports-dir` | `.` | Directory containing JSON audit reports |
+| `--port` | `8080` | Port to listen on (ignored when `--addr` is set) |
+| `--addr` | `127.0.0.1:8080` | Full listen address — override to change host |
+| `--no-open` | `false` | Do not open the browser automatically |
+| `--basic-auth` | _(none)_ | Enable HTTP Basic Auth: `user:pass` |
+
+## Quick start
+
+```bash
+# Run an audit and save the report
+hardbox audit --format json --output /var/log/hardbox/reports/$(date +%s).json
+
+# Start the dashboard
+hardbox serve --reports-dir /var/log/hardbox/reports/
+# → hardbox dashboard → http://127.0.0.1:8080
+```
+
+## Dashboard routes
+
+| Route | Description |
+|---|---|
+| `/` | Report list — all JSON reports sorted by date |
+| `/report/<session_id>` | Single report — findings table per module |
+| `/diff/<before_id>/<after_id>` | Inline diff between two reports |
+| `/api/reports` | JSON API — report metadata list |
+
+## Security
+
+- Binds to `127.0.0.1` by default — not reachable from the network.
+- To expose on the local network (e.g. in a shared lab), set `--addr 0.0.0.0:8080` and protect with `--basic-auth`.
+- Read-only — no write operations are exposed via HTTP.
+- All assets are embedded in the binary via `go:embed` — no external CDN or internet access required.
+
+## Examples
+
+```bash
+# Custom port, no browser
+hardbox serve --port 9000 --reports-dir ./reports/ --no-open
+
+# Shared access with basic auth
+hardbox serve --addr 0.0.0.0:8080 --basic-auth ops:s3cr3t --reports-dir /var/log/hardbox/reports/
+
+# Compare two specific reports from the UI
+# Navigate to: http://127.0.0.1:8080/diff/<before_session_id>/<after_session_id>
+```

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -47,6 +47,7 @@ func newRootCmd(version string) *cobra.Command {
 		newDiffCmd(),
 		newFleetCmd(gf),
 		newPluginCmd(gf),
+		newServeCmd(),
 	)
 
 	return root

--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -1,0 +1,118 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"os/exec"
+	"runtime"
+	"strings"
+
+	"github.com/rs/zerolog/log"
+	"github.com/spf13/cobra"
+
+	"github.com/hardbox-io/hardbox/internal/serve"
+)
+
+func newServeCmd() *cobra.Command {
+	var (
+		port       int
+		addr       string
+		reportsDir string
+		noOpen     bool
+		basicAuth  string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "serve",
+		Short: "Start a local web dashboard to browse audit reports",
+		Long: `serve starts a read-only HTTP dashboard on localhost that lets you
+browse audit reports, inspect findings, and compare any two reports side by side.
+
+The server binds to 127.0.0.1 by default and never exposes to the network
+unless --addr is set explicitly.
+
+Examples:
+  # Start on default port 8080
+  hardbox serve --reports-dir /var/log/hardbox/reports/
+
+  # Custom port
+  hardbox serve --port 9000 --reports-dir ./reports/
+
+  # Bind to custom address with basic auth
+  hardbox serve --addr 0.0.0.0:8080 --basic-auth admin:secret
+
+  # Don't open browser automatically
+  hardbox serve --no-open --reports-dir ./reports/`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			listenAddr := resolveAddr(addr, port)
+
+			cfg := serve.Config{
+				Addr:       listenAddr,
+				ReportsDir: reportsDir,
+				BasicAuth:  basicAuth,
+			}
+
+			srv, err := serve.New(cfg)
+			if err != nil {
+				return fmt.Errorf("creating server: %w", err)
+			}
+
+			url := "http://" + srv.Addr()
+			fmt.Fprintf(cmd.OutOrStdout(), "hardbox dashboard → %s\n", url)
+			fmt.Fprintf(cmd.OutOrStdout(), "reports dir      → %s\n", reportsDir)
+			fmt.Fprintf(cmd.OutOrStdout(), "press Ctrl+C to stop\n\n")
+
+			if !noOpen {
+				go openBrowser(url)
+			}
+
+			log.Debug().Str("addr", listenAddr).Str("reports_dir", reportsDir).Msg("serve: starting")
+			return srv.Start(cmd.Context())
+		},
+	}
+
+	cmd.Flags().IntVar(&port, "port", 8080, "port to listen on (ignored when --addr is set)")
+	cmd.Flags().StringVar(&addr, "addr", "", "full listen address, e.g. 127.0.0.1:8080 (overrides --port)")
+	cmd.Flags().StringVar(&reportsDir, "reports-dir", ".", "directory containing JSON audit reports")
+	cmd.Flags().BoolVar(&noOpen, "no-open", false, "do not open the browser automatically")
+	cmd.Flags().StringVar(&basicAuth, "basic-auth", "", "enable HTTP basic auth, format: user:pass")
+
+	return cmd
+}
+
+// resolveAddr returns the listen address, preferring --addr over --port.
+func resolveAddr(addr string, port int) string {
+	if addr != "" {
+		// Ensure it has a host component — default to 127.0.0.1 for safety.
+		if !strings.Contains(addr, ":") {
+			return net.JoinHostPort("127.0.0.1", addr)
+		}
+		return addr
+	}
+	return net.JoinHostPort("127.0.0.1", fmt.Sprintf("%d", port))
+}
+
+// openBrowser opens url in the user's default browser.
+func openBrowser(url string) {
+	var cmd *exec.Cmd
+	switch runtime.GOOS {
+	case "darwin":
+		cmd = exec.Command("open", url)
+	case "windows":
+		cmd = exec.Command("cmd", "/c", "start", url)
+	default:
+		cmd = exec.Command("xdg-open", url)
+	}
+	if err := cmd.Start(); err != nil {
+		log.Debug().Err(err).Msg("serve: could not open browser")
+	}
+}
+
+// contextKey is unexported to avoid collisions.
+type contextKey struct{ name string }
+
+// WithContext attaches a context to the cobra command (used in tests).
+func withCancelContext(ctx context.Context, cmd *cobra.Command) {
+	cmd.SetContext(ctx)
+}

--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -1,7 +1,6 @@
 package cli
 
 import (
-	"context"
 	"fmt"
 	"net"
 	"os/exec"
@@ -109,10 +108,3 @@ func openBrowser(url string) {
 	}
 }
 
-// contextKey is unexported to avoid collisions.
-type contextKey struct{ name string }
-
-// WithContext attaches a context to the cobra command (used in tests).
-func withCancelContext(ctx context.Context, cmd *cobra.Command) {
-	cmd.SetContext(ctx)
-}

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -1,0 +1,243 @@
+// Package serve implements the hardbox web dashboard HTTP server.
+package serve
+
+import (
+	"context"
+	"embed"
+	"encoding/json"
+	"fmt"
+	"html/template"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/hardbox-io/hardbox/internal/report"
+)
+
+//go:embed templates/*.html
+var templateFS embed.FS
+
+// Config holds the server configuration.
+type Config struct {
+	Addr       string // e.g. "127.0.0.1:8080"
+	ReportsDir string
+	BasicAuth  string // "user:pass" or empty
+}
+
+// Server is the hardbox dashboard HTTP server.
+type Server struct {
+	cfg  Config
+	tmpl *template.Template
+	mux  *http.ServeMux
+}
+
+// New creates a Server and parses the embedded templates.
+func New(cfg Config) (*Server, error) {
+	tmpl, err := template.New("").ParseFS(templateFS, "templates/*.html")
+	if err != nil {
+		return nil, fmt.Errorf("parsing templates: %w", err)
+	}
+
+	s := &Server{cfg: cfg, tmpl: tmpl, mux: http.NewServeMux()}
+	s.routes()
+	return s, nil
+}
+
+// Addr returns the resolved listen address (useful after Start returns it).
+func (s *Server) Addr() string { return s.cfg.Addr }
+
+// Start listens on the configured address and serves until ctx is cancelled.
+func (s *Server) Start(ctx context.Context) error {
+	ln, err := net.Listen("tcp", s.cfg.Addr)
+	if err != nil {
+		return fmt.Errorf("listen %s: %w", s.cfg.Addr, err)
+	}
+	s.cfg.Addr = ln.Addr().String()
+
+	srv := &http.Server{
+		Handler:      s.handler(),
+		ReadTimeout:  10 * time.Second,
+		WriteTimeout: 30 * time.Second,
+		IdleTimeout:  60 * time.Second,
+	}
+
+	errCh := make(chan error, 1)
+	go func() { errCh <- srv.Serve(ln) }()
+
+	select {
+	case <-ctx.Done():
+		shutCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		return srv.Shutdown(shutCtx)
+	case err := <-errCh:
+		return err
+	}
+}
+
+func (s *Server) handler() http.Handler {
+	if s.cfg.BasicAuth == "" {
+		return s.mux
+	}
+	user, pass, ok := strings.Cut(s.cfg.BasicAuth, ":")
+	if !ok {
+		return s.mux
+	}
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		u, p, ok := r.BasicAuth()
+		if !ok || u != user || p != pass {
+			w.Header().Set("WWW-Authenticate", `Basic realm="hardbox"`)
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+		s.mux.ServeHTTP(w, r)
+	})
+}
+
+func (s *Server) routes() {
+	s.mux.HandleFunc("/", s.handleIndex)
+	s.mux.HandleFunc("/report/", s.handleReport)
+	s.mux.HandleFunc("/diff/", s.handleDiff)
+	s.mux.HandleFunc("/api/reports", s.handleAPIReports)
+}
+
+// reportMeta is the report list entry returned by /api/reports.
+type reportMeta struct {
+	SessionID    string    `json:"session_id"`
+	Timestamp    time.Time `json:"timestamp"`
+	Profile      string    `json:"profile"`
+	OverallScore int       `json:"overall_score"`
+	Modules      int       `json:"modules"`
+	File         string    `json:"file"`
+}
+
+func (s *Server) loadReports() ([]*report.Report, error) {
+	entries, err := os.ReadDir(s.cfg.ReportsDir)
+	if err != nil {
+		return nil, fmt.Errorf("reading reports dir %q: %w", s.cfg.ReportsDir, err)
+	}
+
+	var reports []*report.Report
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".json") {
+			continue
+		}
+		path := filepath.Join(s.cfg.ReportsDir, e.Name())
+		data, err := os.ReadFile(path)
+		if err != nil {
+			continue
+		}
+		var r report.Report
+		if err := json.Unmarshal(data, &r); err != nil {
+			continue
+		}
+		// Only include files that look like hardbox reports (have a session_id).
+		if r.SessionID == "" {
+			continue
+		}
+		reports = append(reports, &r)
+	}
+
+	sort.Slice(reports, func(i, j int) bool {
+		return reports[i].Timestamp.After(reports[j].Timestamp)
+	})
+	return reports, nil
+}
+
+func (s *Server) findReport(sessionID string) (*report.Report, error) {
+	reports, err := s.loadReports()
+	if err != nil {
+		return nil, err
+	}
+	for _, r := range reports {
+		if r.SessionID == sessionID {
+			return r, nil
+		}
+	}
+	return nil, fmt.Errorf("report %q not found", sessionID)
+}
+
+// handleIndex renders the report list page.
+func (s *Server) handleIndex(w http.ResponseWriter, r *http.Request) {
+	if r.URL.Path != "/" {
+		http.NotFound(w, r)
+		return
+	}
+	reports, _ := s.loadReports()
+	s.render(w, "index.html", map[string]any{
+		"Reports":    reports,
+		"ReportsDir": s.cfg.ReportsDir,
+	})
+}
+
+// handleReport renders a single report page at /report/<session_id>.
+func (s *Server) handleReport(w http.ResponseWriter, r *http.Request) {
+	id := strings.TrimPrefix(r.URL.Path, "/report/")
+	if id == "" {
+		http.Redirect(w, r, "/", http.StatusFound)
+		return
+	}
+	rep, err := s.findReport(id)
+	if err != nil {
+		http.Error(w, "report not found", http.StatusNotFound)
+		return
+	}
+	s.render(w, "report.html", map[string]any{"Report": rep})
+}
+
+// handleDiff renders the diff page at /diff/<id1>/<id2>.
+func (s *Server) handleDiff(w http.ResponseWriter, r *http.Request) {
+	path := strings.TrimPrefix(r.URL.Path, "/diff/")
+	parts := strings.SplitN(path, "/", 2)
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		http.Error(w, "usage: /diff/<before_id>/<after_id>", http.StatusBadRequest)
+		return
+	}
+
+	before, err := s.findReport(parts[0])
+	if err != nil {
+		http.Error(w, fmt.Sprintf("before report: %v", err), http.StatusNotFound)
+		return
+	}
+	after, err := s.findReport(parts[1])
+	if err != nil {
+		http.Error(w, fmt.Sprintf("after report: %v", err), http.StatusNotFound)
+		return
+	}
+
+	d := report.Diff(before, after)
+	s.render(w, "diff.html", map[string]any{"Diff": d})
+}
+
+// handleAPIReports returns JSON metadata for all reports.
+func (s *Server) handleAPIReports(w http.ResponseWriter, r *http.Request) {
+	reports, err := s.loadReports()
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	meta := make([]reportMeta, 0, len(reports))
+	for _, rep := range reports {
+		meta = append(meta, reportMeta{
+			SessionID:    rep.SessionID,
+			Timestamp:    rep.Timestamp,
+			Profile:      rep.Profile,
+			OverallScore: rep.OverallScore,
+			Modules:      len(rep.Modules),
+		})
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(meta)
+}
+
+func (s *Server) render(w http.ResponseWriter, name string, data any) {
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	if err := s.tmpl.ExecuteTemplate(w, name, data); err != nil {
+		http.Error(w, "render error: "+err.Error(), http.StatusInternalServerError)
+	}
+}

--- a/internal/serve/templates/base.html
+++ b/internal/serve/templates/base.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>{{block "title" .}}hardbox{{end}}</title>
+<style>
+*,*::before,*::after{box-sizing:border-box}
+body{font-family:ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,monospace;font-size:14px;background:#0f1117;color:#e2e8f0;margin:0;padding:0}
+a{color:#60a5fa;text-decoration:none}
+a:hover{text-decoration:underline}
+header{background:#1e2230;border-bottom:1px solid #2d3148;padding:12px 24px;display:flex;align-items:center;gap:16px}
+header h1{margin:0;font-size:16px;font-weight:600;color:#f1f5f9}
+header .badge{background:#312e81;color:#a5b4fc;padding:2px 8px;border-radius:4px;font-size:11px}
+nav a{color:#94a3b8;font-size:13px}
+nav a:hover{color:#e2e8f0}
+main{padding:24px;max-width:1200px;margin:0 auto}
+h2{font-size:15px;font-weight:600;color:#f1f5f9;margin:0 0 16px}
+h3{font-size:13px;font-weight:600;color:#94a3b8;margin:0 0 8px;text-transform:uppercase;letter-spacing:.05em}
+table{width:100%;border-collapse:collapse;font-size:13px}
+th{text-align:left;padding:8px 12px;background:#1e2230;color:#64748b;font-weight:500;border-bottom:1px solid #2d3148;white-space:nowrap}
+td{padding:8px 12px;border-bottom:1px solid #1e2230;vertical-align:top}
+tr:hover td{background:#1a1f2e}
+.card{background:#1e2230;border:1px solid #2d3148;border-radius:8px;padding:20px;margin-bottom:16px}
+.score{font-size:24px;font-weight:700}
+.score.hi{color:#4ade80}
+.score.mid{color:#facc15}
+.score.lo{color:#f87171}
+.pill{display:inline-block;padding:2px 8px;border-radius:9999px;font-size:11px;font-weight:600;text-transform:uppercase}
+.pill.critical{background:#450a0a;color:#f87171}
+.pill.high{background:#431407;color:#fb923c}
+.pill.medium{background:#422006;color:#fbbf24}
+.pill.low{background:#1a2e05;color:#86efac}
+.pill.info{background:#0c1a2e;color:#7dd3fc}
+.pill.compliant{background:#052e16;color:#4ade80}
+.pill.non-compliant{background:#450a0a;color:#f87171}
+.pill.manual{background:#1e1b4b;color:#a5b4fc}
+.pill.skipped{background:#1c1917;color:#a8a29e}
+.pill.error{background:#2d0a0a;color:#fca5a5}
+.meta{color:#64748b;font-size:12px}
+.grid-2{display:grid;grid-template-columns:1fr 1fr;gap:16px}
+.grid-4{display:grid;grid-template-columns:repeat(4,1fr);gap:16px}
+.stat-card{background:#1e2230;border:1px solid #2d3148;border-radius:8px;padding:16px}
+.stat-card .label{color:#64748b;font-size:11px;text-transform:uppercase;letter-spacing:.05em;margin-bottom:4px}
+.stat-card .value{font-size:20px;font-weight:700;color:#f1f5f9}
+.regression{background:#1f0a0a}
+.improvement{background:#071a0f}
+.empty{color:#475569;font-style:italic;padding:16px 12px}
+code{background:#0f1117;padding:1px 6px;border-radius:3px;font-size:12px}
+.breadcrumb{color:#64748b;font-size:12px;margin-bottom:16px}
+.breadcrumb a{color:#94a3b8}
+.section{margin-bottom:32px}
+.diff-badge.reg{background:#450a0a;color:#f87171;padding:2px 8px;border-radius:4px;font-size:11px}
+.diff-badge.imp{background:#052e16;color:#4ade80;padding:2px 8px;border-radius:4px;font-size:11px}
+.diff-badge.neu{background:#1c1917;color:#a8a29e;padding:2px 8px;border-radius:4px;font-size:11px}
+</style>
+</head>
+<body>
+<header>
+  <h1>hardbox</h1>
+  <span class="badge">dashboard</span>
+  <nav style="margin-left:auto"><a href="/">← all reports</a></nav>
+</header>
+<main>
+{{block "content" .}}{{end}}
+</main>
+</body>
+</html>

--- a/internal/serve/templates/diff.html
+++ b/internal/serve/templates/diff.html
@@ -1,0 +1,129 @@
+{{template "base.html" .}}
+{{define "title"}}hardbox — diff{{end}}
+{{define "content"}}
+<div class="breadcrumb"><a href="/">reports</a> / diff</div>
+
+<div class="grid-2" style="margin-bottom:24px">
+  <div class="stat-card">
+    <div class="label">Before — {{.Diff.Before.Timestamp.Format "2006-01-02 15:04"}}</div>
+    <div class="value">{{.Diff.Before.Score}}</div>
+    <div class="meta" style="margin-top:4px"><code>{{.Diff.Before.SessionID}}</code> · {{.Diff.Before.Profile}}</div>
+  </div>
+  <div class="stat-card">
+    <div class="label">After — {{.Diff.After.Timestamp.Format "2006-01-02 15:04"}}</div>
+    <div style="display:flex;align-items:center;gap:12px">
+      <div class="value">{{.Diff.After.Score}}</div>
+      {{$d := .Diff.ScoreDelta}}
+      {{if gt $d 0}}<span style="color:#4ade80;font-weight:700">+{{$d}}</span>
+      {{else if lt $d 0}}<span style="color:#f87171;font-weight:700">{{$d}}</span>
+      {{else}}<span class="meta">±0</span>{{end}}
+    </div>
+    <div class="meta" style="margin-top:4px"><code>{{.Diff.After.SessionID}}</code> · {{.Diff.After.Profile}}</div>
+  </div>
+</div>
+
+<div class="grid-4" style="margin-bottom:24px">
+  <div class="stat-card">
+    <div class="label">Regressions</div>
+    <div class="value" style="color:{{if .Diff.Regressions}}#f87171{{else}}#4ade80{{end}}">{{len .Diff.Regressions}}</div>
+  </div>
+  <div class="stat-card">
+    <div class="label">Improvements</div>
+    <div class="value" style="color:#4ade80">{{len .Diff.Improvements}}</div>
+  </div>
+  <div class="stat-card">
+    <div class="label">Unchanged</div>
+    <div class="value" style="color:#64748b">{{len .Diff.Unchanged}}</div>
+  </div>
+  <div class="stat-card">
+    <div class="label">New Checks</div>
+    <div class="value" style="color:#94a3b8">{{len .Diff.NewChecks}}</div>
+  </div>
+</div>
+
+{{if .Diff.Regressions}}
+<div class="section">
+  <h3 style="color:#f87171">Regressions</h3>
+  <div class="card" style="padding:0">
+  <table>
+    <thead><tr><th>Check</th><th>Title</th><th>Severity</th><th>Before</th><th>After</th></tr></thead>
+    <tbody>
+    {{range .Diff.Regressions}}
+    <tr class="regression">
+      <td><code>{{.CheckID}}</code></td>
+      <td>{{.Title}}{{if .Detail}}<br><span class="meta">{{.Detail}}</span>{{end}}</td>
+      <td><span class="pill {{.Severity}}">{{.Severity}}</span></td>
+      <td><span class="pill {{.StatusBefore}}">{{.StatusBefore}}</span></td>
+      <td><span class="pill {{.StatusAfter}}">{{.StatusAfter}}</span></td>
+    </tr>
+    {{end}}
+    </tbody>
+  </table>
+  </div>
+</div>
+{{end}}
+
+{{if .Diff.Improvements}}
+<div class="section">
+  <h3 style="color:#4ade80">Improvements</h3>
+  <div class="card" style="padding:0">
+  <table>
+    <thead><tr><th>Check</th><th>Title</th><th>Severity</th><th>Before</th><th>After</th></tr></thead>
+    <tbody>
+    {{range .Diff.Improvements}}
+    <tr class="improvement">
+      <td><code>{{.CheckID}}</code></td>
+      <td>{{.Title}}{{if .Detail}}<br><span class="meta">{{.Detail}}</span>{{end}}</td>
+      <td><span class="pill {{.Severity}}">{{.Severity}}</span></td>
+      <td><span class="pill {{.StatusBefore}}">{{.StatusBefore}}</span></td>
+      <td><span class="pill {{.StatusAfter}}">{{.StatusAfter}}</span></td>
+    </tr>
+    {{end}}
+    </tbody>
+  </table>
+  </div>
+</div>
+{{end}}
+
+{{if .Diff.Unchanged}}
+<div class="section">
+  <h3>Unchanged failures</h3>
+  <div class="card" style="padding:0">
+  <table>
+    <thead><tr><th>Check</th><th>Title</th><th>Severity</th><th>Status</th></tr></thead>
+    <tbody>
+    {{range .Diff.Unchanged}}
+    <tr>
+      <td><code>{{.CheckID}}</code></td>
+      <td>{{.Title}}</td>
+      <td><span class="pill {{.Severity}}">{{.Severity}}</span></td>
+      <td><span class="pill {{.StatusAfter}}">{{.StatusAfter}}</span></td>
+    </tr>
+    {{end}}
+    </tbody>
+  </table>
+  </div>
+</div>
+{{end}}
+
+{{if .Diff.NewChecks}}
+<div class="section">
+  <h3>New checks (failing)</h3>
+  <div class="card" style="padding:0">
+  <table>
+    <thead><tr><th>Check</th><th>Title</th><th>Severity</th><th>Status</th></tr></thead>
+    <tbody>
+    {{range .Diff.NewChecks}}
+    <tr>
+      <td><code>{{.CheckID}}</code></td>
+      <td>{{.Title}}</td>
+      <td><span class="pill {{.Severity}}">{{.Severity}}</span></td>
+      <td><span class="pill {{.StatusAfter}}">{{.StatusAfter}}</span></td>
+    </tr>
+    {{end}}
+    </tbody>
+  </table>
+  </div>
+</div>
+{{end}}
+{{end}}

--- a/internal/serve/templates/index.html
+++ b/internal/serve/templates/index.html
@@ -1,0 +1,67 @@
+{{template "base.html" .}}
+{{define "title"}}hardbox — reports{{end}}
+{{define "content"}}
+<h2>Audit Reports</h2>
+<p class="meta">{{len .Reports}} report(s) in <code>{{.ReportsDir}}</code></p>
+
+{{if not .Reports}}
+<div class="card">
+  <p class="empty">No reports found. Run <code>hardbox audit --format json --output report.json</code> to generate one.</p>
+</div>
+{{else}}
+<div class="card" style="padding:0">
+<table>
+  <thead>
+    <tr>
+      <th>Date</th>
+      <th>Session ID</th>
+      <th>Profile</th>
+      <th>Score</th>
+      <th>Modules</th>
+      <th></th>
+    </tr>
+  </thead>
+  <tbody>
+  {{range .Reports}}
+    <tr>
+      <td class="meta">{{.Timestamp.Format "2006-01-02 15:04:05"}}</td>
+      <td><code>{{.SessionID}}</code></td>
+      <td>{{.Profile}}</td>
+      <td>
+        {{$s := .OverallScore}}
+        {{if ge $s 80}}<span class="score hi" style="font-size:14px">{{$s}}</span>
+        {{else if ge $s 50}}<span class="score mid" style="font-size:14px">{{$s}}</span>
+        {{else}}<span class="score lo" style="font-size:14px">{{$s}}</span>{{end}}
+      </td>
+      <td class="meta">{{len .Modules}}</td>
+      <td><a href="/report/{{.SessionID}}">view →</a></td>
+    </tr>
+  {{end}}
+  </tbody>
+</table>
+</div>
+
+{{if gt (len .Reports) 1}}
+<div class="card" style="margin-top:16px">
+  <h3>Compare two reports</h3>
+  <form action="" method="get" id="diff-form" style="display:flex;gap:8px;align-items:center;flex-wrap:wrap">
+    <select name="before" style="background:#0f1117;color:#e2e8f0;border:1px solid #2d3148;padding:6px 10px;border-radius:4px;font-family:inherit;font-size:13px">
+      {{range .Reports}}<option value="{{.SessionID}}">{{.Timestamp.Format "2006-01-02 15:04"}} — {{.SessionID}}</option>{{end}}
+    </select>
+    <span class="meta">vs</span>
+    <select name="after" style="background:#0f1117;color:#e2e8f0;border:1px solid #2d3148;padding:6px 10px;border-radius:4px;font-family:inherit;font-size:13px">
+      {{range .Reports}}<option value="{{.SessionID}}">{{.Timestamp.Format "2006-01-02 15:04"}} — {{.SessionID}}</option>{{end}}
+    </select>
+    <button type="submit" style="background:#312e81;color:#a5b4fc;border:none;padding:6px 16px;border-radius:4px;cursor:pointer;font-family:inherit;font-size:13px">diff →</button>
+  </form>
+</div>
+<script>
+document.getElementById('diff-form').addEventListener('submit',function(e){
+  e.preventDefault();
+  var f=new FormData(this);
+  window.location='/diff/'+f.get('before')+'/'+f.get('after');
+});
+</script>
+{{end}}
+{{end}}
+{{end}}

--- a/internal/serve/templates/report.html
+++ b/internal/serve/templates/report.html
@@ -1,0 +1,65 @@
+{{template "base.html" .}}
+{{define "title"}}hardbox — {{.Report.SessionID}}{{end}}
+{{define "content"}}
+<div class="breadcrumb"><a href="/">reports</a> / {{.Report.SessionID}}</div>
+
+<div class="grid-4" style="margin-bottom:24px">
+  <div class="stat-card">
+    <div class="label">Overall Score</div>
+    {{$s := .Report.OverallScore}}
+    {{if ge $s 80}}<div class="value" style="color:#4ade80">{{$s}}</div>
+    {{else if ge $s 50}}<div class="value" style="color:#facc15">{{$s}}</div>
+    {{else}}<div class="value" style="color:#f87171">{{$s}}</div>{{end}}
+  </div>
+  <div class="stat-card">
+    <div class="label">Profile</div>
+    <div class="value" style="font-size:15px">{{.Report.Profile}}</div>
+  </div>
+  <div class="stat-card">
+    <div class="label">Modules</div>
+    <div class="value">{{len .Report.Modules}}</div>
+  </div>
+  <div class="stat-card">
+    <div class="label">Timestamp</div>
+    <div class="value" style="font-size:13px;margin-top:4px">{{.Report.Timestamp.Format "2006-01-02 15:04:05"}}</div>
+  </div>
+</div>
+
+{{range .Report.Modules}}
+<div class="section">
+  <div style="display:flex;align-items:center;gap:12px;margin-bottom:8px">
+    <h3 style="margin:0">{{.Name}}</h3>
+    {{$ms := .Score}}
+    {{if ge $ms 80}}<span style="color:#4ade80;font-size:12px;font-weight:700">{{$ms}}%</span>
+    {{else if ge $ms 50}}<span style="color:#facc15;font-size:12px;font-weight:700">{{$ms}}%</span>
+    {{else}}<span style="color:#f87171;font-size:12px;font-weight:700">{{$ms}}%</span>{{end}}
+  </div>
+  <div class="card" style="padding:0">
+  <table>
+    <thead>
+      <tr>
+        <th>Check</th>
+        <th>Title</th>
+        <th>Status</th>
+        <th>Severity</th>
+        <th>Current</th>
+        <th>Target</th>
+      </tr>
+    </thead>
+    <tbody>
+    {{range .Findings}}
+      <tr>
+        <td><code>{{.CheckID}}</code></td>
+        <td>{{.Title}}{{if .Detail}}<br><span class="meta">{{.Detail}}</span>{{end}}</td>
+        <td><span class="pill {{.Status}}">{{.Status}}</span></td>
+        <td><span class="pill {{.Severity}}">{{.Severity}}</span></td>
+        <td class="meta">{{if .Current}}{{.Current}}{{else}}—{{end}}</td>
+        <td class="meta">{{if .Target}}{{.Target}}{{else}}—{{end}}</td>
+      </tr>
+    {{end}}
+    </tbody>
+  </table>
+  </div>
+</div>
+{{end}}
+{{end}}


### PR DESCRIPTION
## Summary

Implements `hardbox serve` (#125) — a read-only local HTTP dashboard for browsing audit reports without leaving the browser.

- New `hardbox serve` subcommand starts an HTTP server on `127.0.0.1:8080` (default)
- Dashboard lists all JSON reports in `--reports-dir`, sorted by date
- Single-report view with per-module findings table (status, severity, current/target values)
- Diff view at `/diff/<before_id>/<after_id>` — regressions, improvements, unchanged failures, new checks
- JSON API at `/api/reports` for report metadata
- All HTML/CSS assets embedded in the binary via `go:embed` — no external CDN

## Flags

| Flag | Default | Description |
|---|---|---|
| `--reports-dir` | `.` | Directory containing JSON audit reports |
| `--port` | `8080` | Listen port |
| `--addr` | — | Full address override (e.g. `0.0.0.0:8080`) |
| `--no-open` | `false` | Skip auto-opening the browser |
| `--basic-auth` | — | Enable Basic Auth: `user:pass` |

## Security

- Binds to `127.0.0.1` by default — never exposes to the network without explicit `--addr`
- Read-only — no write operations via HTTP
- No external CDN dependencies — all assets embedded via `go:embed`

## Files

| File | Description |
|---|---|
| `internal/serve/serve.go` | HTTP server, routes, handlers, graceful shutdown |
| `internal/serve/templates/*.html` | Embedded HTML templates (base, index, report, diff) |
| `internal/cli/serve.go` | Cobra subcommand |
| `internal/cli/root.go` | Register `newServeCmd()` |
| `docs/SERVE.md` | Usage guide |

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `go test ./...` — all pass
- [x] `hardbox serve --help` shows all flags
- [ ] Manual: `hardbox serve --reports-dir <dir>` — dashboard loads, reports listed
- [ ] Manual: `/report/<id>` — findings table renders per module
- [ ] Manual: `/diff/<id1>/<id2>` — regressions/improvements shown
- [ ] Manual: `/api/reports` — JSON response

Closes #125

🤖 Generated with [Claude Code](https://claude.com/claude-code)