### PR TITLE
license: migrate from MIT to AGPL v3

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -234,4 +234,4 @@ Operational guidance for branch protection, release publication, and smoke valid
 
 ## License
 
-By contributing you agree that your contributions will be licensed under the [MIT License](LICENSE).
+By contributing you agree that your contributions will be licensed under the [GNU Affero General Public License v3](LICENSE).

--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,660 @@
-MIT License
+                    GNU AFFERO GENERAL PUBLIC LICENSE
+                       Version 3, 19 November 2007
 
-Copyright (c) 2026 jackby03
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+                            Preamble
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+  The GNU Affero General Public License is a free, copyleft license for
+software and other kinds of works, specifically designed to ensure
+cooperation with the community in the case of network server software.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+our General Public Licenses are intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  Developers that use our General Public Licenses protect your rights
+with two steps: (1) assert copyright on the software, and (2) offer
+you this License which gives you legal permission to copy, distribute
+and/or modify the software.
+
+  A secondary benefit of defending all users' freedom is that
+improvements made in alternate versions of the program, if they
+receive widespread use, become available for other developers to
+incorporate.  Many developers of free software are heartened and
+encouraged by the resulting cooperation.  However, in the case of
+software used on network servers, this result may fail to come about.
+The GNU General Public License permits making a modified version and
+letting the public access it on a server without ever releasing its
+source code to the public.
+
+  The GNU Affero General Public License is designed specifically to
+ensure that, in such cases, the modified source code becomes available
+to the community.  It requires the operator of a network server to
+provide the source code of the modified version running there to the
+users of that server.  Therefore, public use of a modified version, on
+a publicly accessible server, gives the public access to the source
+code of the modified version.
+
+  An older license, called the Affero General Public License and
+published by Affero, was designed to accomplish similar goals.  This is
+a different license, not a version of the Affero GPL, but Affero has
+released a new version of the Affero GPL which permits relicensing under
+this license.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU Affero General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Remote Network Interaction; Use with the GNU General Public License.
+
+  Notwithstanding any other provision of this License, if you modify the
+Program, your modified version must prominently offer all users
+interacting with it remotely through a computer network (if your version
+supports such interaction) an opportunity to receive the Corresponding
+Source of your version by providing access to the Corresponding Source
+from a network server at no charge, through some standard or customary
+means of facilitating copying of software.  This Corresponding Source
+shall include the Corresponding Source for any work covered by version 3
+of the GNU General Public License that is incorporated pursuant to the
+following paragraph.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the work with which it is combined will remain governed by version
+3 of the GNU General Public License.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU Affero General Public License from time to time.  Such new versions
+will be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU Affero General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU Affero General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU Affero General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If your software can interact with users remotely through a computer
+network, you should also make sure that it provides a way for users to
+get its source.  For example, if your program is a web application, its
+interface could display a "Source" link that leads users to an archive
+of the code.  There are many ways you could offer source, and different
+solutions will be better for different programs; see section 13 for the
+specific requirements.
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU AGPL, see
+<https://www.gnu.org/licenses/>.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,8 @@
+hardbox
+Copyright (C) 2024 Jack (jackby03)
+
+This product includes software developed by the hardbox project.
+https://github.com/jackby03/hardbox
+
+Previously distributed under the MIT License.
+Re-licensed to GNU Affero General Public License v3 as of April 2026.

--- a/README.md
+++ b/README.md
@@ -326,7 +326,7 @@ the terms of the GNU Affero General Public License as published by the
 Free Software Foundation, either version 3 of the License.
 
 For commercial use without AGPL obligations, a commercial license is available.
-Contact: [jackby03@protonmail.com](mailto:jackby03@protonmail.com)
+Contact: jackby03@protonmail.com
 
 See [LICENSE](./LICENSE) for full terms.
 

--- a/README.md
+++ b/README.md
@@ -321,7 +321,14 @@ If hardbox saves you time or helps keep your infrastructure secure, consider sup
 
 ## License
 
-[MIT License](LICENSE) — free for personal, commercial, and government use.
+hardbox is free software: you can redistribute it and/or modify it under
+the terms of the GNU Affero General Public License as published by the
+Free Software Foundation, either version 3 of the License.
+
+For commercial use without AGPL obligations, a commercial license is available.
+Contact: [jackby03@protonmail.com](mailto:jackby03@protonmail.com)
+
+See [LICENSE](./LICENSE) for full terms.
 
 ---
 

--- a/ansible-role/hardbox/README.md
+++ b/ansible-role/hardbox/README.md
@@ -1,7 +1,7 @@
 # Ansible Role: hardbox
 
 [![Ansible Galaxy](https://img.shields.io/badge/galaxy-jackby03.hardbox-blue)](https://galaxy.ansible.com/jackby03/hardbox)
-[![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](../../LICENSE)
+[![License: AGPL v3](https://img.shields.io/badge/License-AGPL_v3-blue.svg)](../../LICENSE)
 
 Installs and runs [hardbox](https://github.com/jackby03/hardbox) — a Linux OS hardening tool with built-in compliance profiles.
 
@@ -106,4 +106,4 @@ ansible-galaxy install -r requirements.yml
 
 ## License
 
-MIT — see [LICENSE](../../LICENSE).
+AGPL v3 — see [LICENSE](../../LICENSE).

--- a/ansible-role/hardbox/meta/main.yml
+++ b/ansible-role/hardbox/meta/main.yml
@@ -6,7 +6,7 @@ galaxy_info:
     Ansible role to install, configure, and run hardbox — a Linux system
     hardening tool with built-in compliance profiles (CIS, NIST, STIG,
     PCI-DSS, HIPAA, ISO 27001, and cloud provider benchmarks).
-  license: MIT
+  license: AGPL-3.0
   min_ansible_version: "2.14"
 
   platforms:

--- a/cmd/hardbox/main.go
+++ b/cmd/hardbox/main.go
@@ -1,3 +1,17 @@
+// Copyright (C) 2024 Jack (jackby03)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
 package main
 
 import (
@@ -15,3 +29,4 @@ func main() {
 		os.Exit(1)
 	}
 }
+

--- a/cmd/hardbox/main_test.go
+++ b/cmd/hardbox/main_test.go
@@ -1,3 +1,17 @@
+// Copyright (C) 2024 Jack (jackby03)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
 package main
 
 import "testing"
@@ -5,3 +19,4 @@ import "testing"
 // TestMain_Compiles is a compile-time smoke test.
 // All CLI logic has moved to internal/cli — see internal/cli/root_test.go.
 func TestMain_Compiles(t *testing.T) {}
+

--- a/configs/profiles/embed.go
+++ b/configs/profiles/embed.go
@@ -1,6 +1,21 @@
+// Copyright (C) 2024 Jack (jackby03)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
 package profiles
 
 import "embed"
 
 //go:embed *.yaml
 var Files embed.FS
+

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -222,7 +222,7 @@ The value proposition is not locked features — it is **managed infrastructure,
 
 | | Lynis | hardbox |
 |---|---|---|
-| License | GPL | MIT |
+| License | GPL | AGPL v3 |
 | Remediation | Enterprise (paid) | **Always free** |
 | Multi-host | No | `hardbox fleet` |
 | CI/CD integration | Manual | Native (`diff`, SARIF, exit codes) |

--- a/examples/plugin-custom-check/plugin.go
+++ b/examples/plugin-custom-check/plugin.go
@@ -1,3 +1,17 @@
+// Copyright (C) 2024 Jack (jackby03)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
 // Package main is an example hardbox plugin that checks whether the /tmp
 // directory has the sticky bit set (permissions 1777). This is a real
 // hardening requirement: without the sticky bit, any user can delete files
@@ -101,3 +115,4 @@ func New() sdk.Module {
 // main is required so the file compiles with `go build` in addition to
 // `go build -buildmode=plugin`. It is not called when loaded as a plugin.
 func main() {}
+

--- a/internal/cli/apply.go
+++ b/internal/cli/apply.go
@@ -1,3 +1,17 @@
+// Copyright (C) 2024 Jack (jackby03)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
 package cli
 
 import (
@@ -40,3 +54,4 @@ func newApplyCmd(gf *globalFlags) *cobra.Command {
 
 	return cmd
 }
+

--- a/internal/cli/audit.go
+++ b/internal/cli/audit.go
@@ -1,3 +1,17 @@
+// Copyright (C) 2024 Jack (jackby03)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
 package cli
 
 import (
@@ -34,3 +48,4 @@ func newAuditCmd(gf *globalFlags) *cobra.Command {
 
 	return cmd
 }
+

--- a/internal/cli/diff.go
+++ b/internal/cli/diff.go
@@ -1,3 +1,17 @@
+// Copyright (C) 2024 Jack (jackby03)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
 package cli
 
 import (
@@ -71,3 +85,4 @@ Examples:
 
 	return cmd
 }
+

--- a/internal/cli/export_test.go
+++ b/internal/cli/export_test.go
@@ -1,3 +1,17 @@
+// Copyright (C) 2024 Jack (jackby03)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
 package cli
 
 import "github.com/spf13/cobra"
@@ -13,3 +27,4 @@ func NewRootCmdForTest(version string) *cobra.Command {
 func NewWatchCmdForTest() *cobra.Command {
 	return newWatchCmd(&globalFlags{profile: "production", logLevel: "info"})
 }
+

--- a/internal/cli/fleet.go
+++ b/internal/cli/fleet.go
@@ -1,3 +1,17 @@
+// Copyright (C) 2024 Jack (jackby03)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
 package cli
 
 import (
@@ -207,3 +221,4 @@ func countResults(results []fleet.HostResult) (passed, failed int) {
 	}
 	return
 }
+

--- a/internal/cli/plugin.go
+++ b/internal/cli/plugin.go
@@ -1,3 +1,17 @@
+// Copyright (C) 2024 Jack (jackby03)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
 package cli
 
 import (
@@ -104,3 +118,4 @@ func copyFile(src, dst string) error {
 	}
 	return out.Close()
 }
+

--- a/internal/cli/rollback.go
+++ b/internal/cli/rollback.go
@@ -1,3 +1,17 @@
+// Copyright (C) 2024 Jack (jackby03)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
 package cli
 
 import (
@@ -49,3 +63,4 @@ func newRollbackApplyCmd() *cobra.Command {
 
 	return cmd
 }
+

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -1,3 +1,17 @@
+// Copyright (C) 2024 Jack (jackby03)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
 package cli
 
 import (
@@ -65,3 +79,4 @@ func applyLogLevel(level string) error {
 	zerolog.SetGlobalLevel(lvl)
 	return nil
 }
+

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -1,3 +1,17 @@
+// Copyright (C) 2024 Jack (jackby03)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
 package cli_test
 
 import (
@@ -85,3 +99,4 @@ func TestRootCmd_SubcommandsRegistered(t *testing.T) {
 		}
 	}
 }
+

--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -1,3 +1,17 @@
+// Copyright (C) 2024 Jack (jackby03)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
 package cli
 
 import (
@@ -107,3 +121,4 @@ func openBrowser(url string) {
 		log.Debug().Err(err).Msg("serve: could not open browser")
 	}
 }
+

--- a/internal/cli/watch.go
+++ b/internal/cli/watch.go
@@ -1,3 +1,17 @@
+// Copyright (C) 2024 Jack (jackby03)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
 package cli
 
 import (
@@ -160,3 +174,4 @@ func writeWatchReport(r *report.Report, path string) error {
 	}
 	return util.AtomicWrite(path, data, 0o600)
 }
+

--- a/internal/cli/watch_test.go
+++ b/internal/cli/watch_test.go
@@ -1,3 +1,17 @@
+// Copyright (C) 2024 Jack (jackby03)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
 package cli_test
 
 import (
@@ -86,3 +100,4 @@ func TestWatchCmd_InheritsLogLevel(t *testing.T) {
 		t.Fatal("--profile should be inherited by the watch subcommand")
 	}
 }
+

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,3 +1,17 @@
+// Copyright (C) 2024 Jack (jackby03)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
 package config
 
 import (
@@ -263,3 +277,4 @@ func setDefaults(v *viper.Viper) {
 	v.SetDefault("watch.max_runs", 0)
 	v.SetDefault("plugin_dir", "/etc/hardbox/plugins")
 }
+

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,3 +1,17 @@
+// Copyright (C) 2024 Jack (jackby03)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
 package config
 
 import (
@@ -362,3 +376,4 @@ func TestLoad_InheritanceDepthLimit(t *testing.T) {
 		t.Errorf("Expected depth error, got: %v", err)
 	}
 }
+

--- a/internal/distro/distro.go
+++ b/internal/distro/distro.go
@@ -1,3 +1,17 @@
+// Copyright (C) 2024 Jack (jackby03)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
 // Package distro detects the Linux distribution and version at runtime.
 // It reads /etc/os-release (primary source) and falls back to
 // /etc/lsb-release and /etc/redhat-release for older systems.
@@ -167,3 +181,4 @@ func resolveFamily(id, idLike string) Family {
 	}
 	return FamilyUnknown
 }
+

--- a/internal/distro/distro_test.go
+++ b/internal/distro/distro_test.go
@@ -1,3 +1,17 @@
+// Copyright (C) 2024 Jack (jackby03)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
 package distro_test
 
 import (
@@ -113,3 +127,4 @@ func assertEqual(t *testing.T, field, want, got string) {
 		t.Errorf("%s: want %q, got %q", field, want, got)
 	}
 }
+

--- a/internal/distro/export_test.go
+++ b/internal/distro/export_test.go
@@ -1,5 +1,20 @@
+// Copyright (C) 2024 Jack (jackby03)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
 package distro
 
 // TestDetectFromPaths exposes the internal detectFromPaths function for use in
 // tests outside this package. It is only compiled during testing.
 var TestDetectFromPaths = detectFromPaths
+

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -1,3 +1,17 @@
+// Copyright (C) 2024 Jack (jackby03)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
 package engine
 
 import (
@@ -337,3 +351,4 @@ func formatExtension(format string) string {
 		return ".txt"
 	}
 }
+

--- a/internal/engine/registry.go
+++ b/internal/engine/registry.go
@@ -1,3 +1,17 @@
+// Copyright (C) 2024 Jack (jackby03)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
 package engine
 
 import (
@@ -44,3 +58,4 @@ func registeredModules() []modules.Module {
 		// &pam.Module{},
 	}
 }
+

--- a/internal/engine/registry_test.go
+++ b/internal/engine/registry_test.go
@@ -1,3 +1,17 @@
+// Copyright (C) 2024 Jack (jackby03)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
 package engine
 
 import (
@@ -26,3 +40,4 @@ func TestRegisteredModules_NoDuplicates(t *testing.T) {
 		seen[m.Name()] = true
 	}
 }
+

--- a/internal/engine/snapshot.go
+++ b/internal/engine/snapshot.go
@@ -1,3 +1,17 @@
+// Copyright (C) 2024 Jack (jackby03)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
 package engine
 
 import (
@@ -168,3 +182,4 @@ func latestSnapshot() (*snapshot, error) {
 	}
 	return snaps[0], nil
 }
+

--- a/internal/fleet/fleet.go
+++ b/internal/fleet/fleet.go
@@ -1,3 +1,17 @@
+// Copyright (C) 2024 Jack (jackby03)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
 package fleet
 
 import (
@@ -155,3 +169,4 @@ func HasCritical(results []HostResult) bool {
 	}
 	return false
 }
+

--- a/internal/fleet/host.go
+++ b/internal/fleet/host.go
@@ -1,3 +1,17 @@
+// Copyright (C) 2024 Jack (jackby03)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
 // Package fleet provides concurrent multi-host hardening via SSH.
 package fleet
 
@@ -103,3 +117,4 @@ func parseHostEntry(s string) (Host, error) {
 
 	return Host{User: user, Addr: addr, Port: port}, nil
 }
+

--- a/internal/fleet/report.go
+++ b/internal/fleet/report.go
@@ -1,3 +1,17 @@
+// Copyright (C) 2024 Jack (jackby03)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
 package fleet
 
 import (
@@ -154,3 +168,4 @@ func countOutcomes(results []HostResult) (passed, failed int) {
 	}
 	return
 }
+

--- a/internal/fleet/ssh.go
+++ b/internal/fleet/ssh.go
@@ -1,3 +1,17 @@
+// Copyright (C) 2024 Jack (jackby03)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
 package fleet
 
 import (
@@ -81,3 +95,4 @@ func (c *sshClient) target() string {
 func shellQuote(s string) string {
 	return "'" + strings.ReplaceAll(s, "'", "'\\''") + "'"
 }
+

--- a/internal/modules/auditd/checks.go
+++ b/internal/modules/auditd/checks.go
@@ -1,3 +1,17 @@
+// Copyright (C) 2024 Jack (jackby03)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
 package auditd
 
 import "github.com/hardbox-io/hardbox/internal/modules"
@@ -196,3 +210,4 @@ func checkAUD013() modules.Check {
 		},
 	}
 }
+

--- a/internal/modules/auditd/export_test.go
+++ b/internal/modules/auditd/export_test.go
@@ -1,3 +1,17 @@
+// Copyright (C) 2024 Jack (jackby03)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
 // export_test.go exposes internal constructor knobs for package-external tests.
 package auditd
 
@@ -18,3 +32,4 @@ func NewModuleForTest(
 
 // HardboxRulesContent exposes the hardened rules string for test assertions.
 func HardboxRulesContent() string { return hardboxRulesContent() }
+

--- a/internal/modules/auditd/module.go
+++ b/internal/modules/auditd/module.go
@@ -1,3 +1,17 @@
+// Copyright (C) 2024 Jack (jackby03)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
 package auditd
 
 import (
@@ -368,3 +382,4 @@ func runCommand(ctx context.Context, name string, args ...string) (string, error
 	}
 	return result, nil
 }
+

--- a/internal/modules/auditd/module_test.go
+++ b/internal/modules/auditd/module_test.go
@@ -1,3 +1,17 @@
+// Copyright (C) 2024 Jack (jackby03)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
 package auditd_test
 
 import (
@@ -283,3 +297,4 @@ func TestPlan_ApplyRevert(t *testing.T) {
 		t.Error("expected rules file to be removed after Revert()")
 	}
 }
+

--- a/internal/modules/containers/checks.go
+++ b/internal/modules/containers/checks.go
@@ -1,3 +1,17 @@
+// Copyright (C) 2024 Jack (jackby03)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
 package containers
 
 import "github.com/hardbox-io/hardbox/internal/modules"
@@ -147,3 +161,4 @@ func checkCNT010() modules.Check {
 		},
 	}
 }
+

--- a/internal/modules/containers/export_test.go
+++ b/internal/modules/containers/export_test.go
@@ -1,3 +1,17 @@
+// Copyright (C) 2024 Jack (jackby03)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
 package containers
 
 // NewModuleForTest builds a containers module with injectable dependencies.
@@ -21,3 +35,4 @@ var (
 	PrivilegedFmt   = privilegedFmt
 	MountsFmt       = mountsFmt
 )
+

--- a/internal/modules/containers/module.go
+++ b/internal/modules/containers/module.go
@@ -1,3 +1,17 @@
+// Copyright (C) 2024 Jack (jackby03)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
 package containers
 
 import (
@@ -398,3 +412,4 @@ func (m *Module) findAuditRules() modules.Finding {
 		Detail:  "Add '-w /var/run/docker.sock -p rwxa -k docker' to /etc/audit/rules.d/docker.rules.",
 	}
 }
+

--- a/internal/modules/containers/module_test.go
+++ b/internal/modules/containers/module_test.go
@@ -1,3 +1,17 @@
+// Copyright (C) 2024 Jack (jackby03)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
 package containers_test
 
 import (
@@ -469,3 +483,4 @@ func TestAudit_AuditRuleMissing(t *testing.T) {
 	}
 	assertStatus(t, findings, "cnt-010", modules.StatusNonCompliant)
 }
+

--- a/internal/modules/crypto/checks.go
+++ b/internal/modules/crypto/checks.go
@@ -1,3 +1,17 @@
+// Copyright (C) 2024 Jack (jackby03)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
 package crypto
 
 import "github.com/hardbox-io/hardbox/internal/modules"
@@ -66,3 +80,4 @@ func checkCRY006() modules.Check {
 		Severity:    modules.SeverityLow,
 	}
 }
+

--- a/internal/modules/crypto/export_test.go
+++ b/internal/modules/crypto/export_test.go
@@ -1,3 +1,17 @@
+// Copyright (C) 2024 Jack (jackby03)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
 package crypto
 
 import "github.com/hardbox-io/hardbox/internal/distro"
@@ -32,3 +46,4 @@ func FakeDistroDebian() (*distro.Info, error) {
 func FakeDistroRHEL() (*distro.Info, error) {
 	return &distro.Info{ID: "rhel", Family: distro.FamilyRHEL}, nil
 }
+

--- a/internal/modules/crypto/module.go
+++ b/internal/modules/crypto/module.go
@@ -1,3 +1,17 @@
+// Copyright (C) 2024 Jack (jackby03)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
 package crypto
 
 import (
@@ -348,3 +362,4 @@ func orUnknown(v string) string {
 	}
 	return strings.TrimSpace(v)
 }
+

--- a/internal/modules/crypto/module_bench_test.go
+++ b/internal/modules/crypto/module_bench_test.go
@@ -1,3 +1,17 @@
+// Copyright (C) 2024 Jack (jackby03)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
 package crypto
 
 import (
@@ -39,3 +53,4 @@ CipherString = DEFAULT@SECLEVEL=2
 		parseOpenSSLCipherString(content)
 	}
 }
+

--- a/internal/modules/crypto/module_test.go
+++ b/internal/modules/crypto/module_test.go
@@ -1,3 +1,17 @@
+// Copyright (C) 2024 Jack (jackby03)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
 package crypto_test
 
 import (
@@ -155,3 +169,4 @@ func assertStatus(t *testing.T, findings []modules.Finding, id string, want modu
 	}
 	t.Fatalf("check %s not found", id)
 }
+

--- a/internal/modules/filesystem/checks.go
+++ b/internal/modules/filesystem/checks.go
@@ -1,3 +1,17 @@
+// Copyright (C) 2024 Jack (jackby03)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
 package filesystem
 
 import (
@@ -257,3 +271,4 @@ func filePermChecks() []filePermSpec {
 		},
 	}
 }
+

--- a/internal/modules/filesystem/export_test.go
+++ b/internal/modules/filesystem/export_test.go
@@ -1,3 +1,17 @@
+// Copyright (C) 2024 Jack (jackby03)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
 // export_test.go exposes internal constructor knobs for package-external tests.
 package filesystem
 
@@ -12,3 +26,4 @@ func NewModuleForTest(mountsPath, fsRoot, fstabPath string) *Module {
 		fstabPath:  fstabPath,
 	}
 }
+

--- a/internal/modules/filesystem/module.go
+++ b/internal/modules/filesystem/module.go
@@ -1,3 +1,17 @@
+// Copyright (C) 2024 Jack (jackby03)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
 // Package filesystem implements filesystem security hardening checks.
 // It covers mount options (fs-001..007), file permissions (fs-010..014),
 // world-writable files (fs-015), unowned files (fs-016), SUID/SGID
@@ -729,3 +743,4 @@ func addFstabOptions(content, mountpoint string, addOpts []string) string {
 
 	return strings.Join(lines, "\n")
 }
+

--- a/internal/modules/filesystem/module_test.go
+++ b/internal/modules/filesystem/module_test.go
@@ -1,3 +1,17 @@
+// Copyright (C) 2024 Jack (jackby03)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
 package filesystem_test
 
 import (
@@ -577,3 +591,4 @@ func TestPlan_StickyBit_ApplyRevert(t *testing.T) {
 		t.Error("sticky bit should be cleared after Revert()")
 	}
 }
+

--- a/internal/modules/filesystem/stat_other.go
+++ b/internal/modules/filesystem/stat_other.go
@@ -1,3 +1,17 @@
+// Copyright (C) 2024 Jack (jackby03)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
 //go:build !unix
 
 package filesystem
@@ -8,3 +22,4 @@ import "os"
 func statOwner(_ os.FileInfo) (uid, gid uint32, ok bool) {
 	return 0, 0, false
 }
+

--- a/internal/modules/filesystem/stat_unix.go
+++ b/internal/modules/filesystem/stat_unix.go
@@ -1,3 +1,17 @@
+// Copyright (C) 2024 Jack (jackby03)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
 //go:build unix
 
 package filesystem
@@ -15,3 +29,4 @@ func statOwner(info os.FileInfo) (uid, gid uint32, ok bool) {
 	}
 	return st.Uid, st.Gid, true
 }
+

--- a/internal/modules/firewall/checks.go
+++ b/internal/modules/firewall/checks.go
@@ -1,3 +1,17 @@
+// Copyright (C) 2024 Jack (jackby03)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
 package firewall
 
 import "github.com/hardbox-io/hardbox/internal/modules"
@@ -67,3 +81,4 @@ func checkFW006() modules.Check {
 		Compliance:  []modules.ComplianceRef{{Framework: "CIS", Control: "3.5.2"}, {Framework: "NIST", Control: "SC-7"}},
 	}
 }
+

--- a/internal/modules/firewall/export_test.go
+++ b/internal/modules/firewall/export_test.go
@@ -1,3 +1,17 @@
+// Copyright (C) 2024 Jack (jackby03)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
 package firewall
 
 import "github.com/hardbox-io/hardbox/internal/distro"
@@ -31,3 +45,4 @@ func FakeDistroDebian() (*distro.Info, error) {
 func FakeDistroRHEL() (*distro.Info, error) {
 	return &distro.Info{ID: "rocky", Family: distro.FamilyRHEL}, nil
 }
+

--- a/internal/modules/firewall/module.go
+++ b/internal/modules/firewall/module.go
@@ -1,3 +1,17 @@
+// Copyright (C) 2024 Jack (jackby03)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
 package firewall
 
 import (
@@ -481,3 +495,4 @@ func runCommand(ctx context.Context, name string, args ...string) (string, error
 	}
 	return result, nil
 }
+

--- a/internal/modules/firewall/module_test.go
+++ b/internal/modules/firewall/module_test.go
@@ -1,3 +1,17 @@
+// Copyright (C) 2024 Jack (jackby03)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
 package firewall_test
 
 import (
@@ -213,3 +227,4 @@ func writeIPv6DisableFile(t *testing.T, content string) string {
 
 func alwaysTrue(string) bool  { return true }
 func alwaysFalse(string) bool { return false }
+

--- a/internal/modules/kernel/checks.go
+++ b/internal/modules/kernel/checks.go
@@ -1,3 +1,17 @@
+// Copyright (C) 2024 Jack (jackby03)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
 package kernel
 
 import "github.com/hardbox-io/hardbox/internal/modules"
@@ -272,3 +286,4 @@ func allChecks() []sysctlCheck {
 		},
 	}
 }
+

--- a/internal/modules/kernel/export_test.go
+++ b/internal/modules/kernel/export_test.go
@@ -1,3 +1,17 @@
+// Copyright (C) 2024 Jack (jackby03)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
 // export_test.go exposes internal fields for package-external tests only.
 package kernel
 
@@ -5,3 +19,4 @@ package kernel
 func NewModuleWithProcBase(procBase string) *Module {
 	return &Module{procBase: procBase}
 }
+

--- a/internal/modules/kernel/module.go
+++ b/internal/modules/kernel/module.go
@@ -1,3 +1,17 @@
+// Copyright (C) 2024 Jack (jackby03)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
 // Package kernel implements sysctl-based kernel hardening checks.
 // It covers network protection (kn-001..011) and memory/process protection
 // (km-001..008) derived from CIS Benchmark Level 1.
@@ -160,3 +174,4 @@ func (m *Module) readSysctl(param string) (string, error) {
 	}
 	return strings.TrimSpace(string(data)), nil
 }
+

--- a/internal/modules/kernel/module_test.go
+++ b/internal/modules/kernel/module_test.go
@@ -1,3 +1,17 @@
+// Copyright (C) 2024 Jack (jackby03)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
 package kernel_test
 
 import (
@@ -184,3 +198,4 @@ func TestAudit_SkipsUnknownParams(t *testing.T) {
 		}
 	}
 }
+

--- a/internal/modules/logging/checks.go
+++ b/internal/modules/logging/checks.go
@@ -1,3 +1,17 @@
+// Copyright (C) 2024 Jack (jackby03)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
 package logging
 
 import "github.com/hardbox-io/hardbox/internal/modules"
@@ -105,3 +119,4 @@ func checkLOG007() modules.Check {
 		},
 	}
 }
+

--- a/internal/modules/logging/export_test.go
+++ b/internal/modules/logging/export_test.go
@@ -1,3 +1,17 @@
+// Copyright (C) 2024 Jack (jackby03)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
 package logging
 
 // NewModuleForTest creates a Module with injected paths and command runner for testing.
@@ -21,3 +35,4 @@ var SetJournaldKey = setJournaldKey
 
 // RsyslogHasRemoteForwarding exposes the pure helper for unit tests.
 var RsyslogHasRemoteForwarding = rsyslogHasRemoteForwarding
+

--- a/internal/modules/logging/module.go
+++ b/internal/modules/logging/module.go
@@ -1,3 +1,17 @@
+// Copyright (C) 2024 Jack (jackby03)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
 package logging
 
 import (
@@ -482,3 +496,4 @@ func runCommand(ctx context.Context, name string, args ...string) (string, error
 	}
 	return result, nil
 }
+

--- a/internal/modules/logging/module_test.go
+++ b/internal/modules/logging/module_test.go
@@ -1,3 +1,17 @@
+// Copyright (C) 2024 Jack (jackby03)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
 package logging_test
 
 import (
@@ -355,3 +369,4 @@ func TestPlan_AlreadyCompliant_NoChanges(t *testing.T) {
 		t.Errorf("expected 0 changes when already compliant, got %d", len(changes))
 	}
 }
+

--- a/internal/modules/mac/export_test.go
+++ b/internal/modules/mac/export_test.go
@@ -1,3 +1,17 @@
+// Copyright (C) 2024 Jack (jackby03)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
 package mac
 
 import "context"
@@ -19,3 +33,4 @@ func NewModuleForTest(o TestOptions) *Module {
 		apparmorEnabled: o.AppArmorEnabled,
 	}
 }
+

--- a/internal/modules/mac/module.go
+++ b/internal/modules/mac/module.go
@@ -1,3 +1,17 @@
+// Copyright (C) 2024 Jack (jackby03)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
 package mac
 
 import (
@@ -300,3 +314,4 @@ func cfgString(cfg modules.ModuleConfig, key, fallback string) string {
 func newSkipped(chk modules.Check, current, target, detail string) modules.Finding {
 	return modules.Finding{Check: chk, Status: modules.StatusSkipped, Current: current, Target: target, Detail: detail}
 }
+

--- a/internal/modules/mac/module_test.go
+++ b/internal/modules/mac/module_test.go
@@ -1,3 +1,17 @@
+// Copyright (C) 2024 Jack (jackby03)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
 package mac_test
 
 import (
@@ -154,3 +168,4 @@ func assertStatus(t *testing.T, findings []modules.Finding, id string, want modu
 	}
 	t.Fatalf("check %s not found", id)
 }
+

--- a/internal/modules/module.go
+++ b/internal/modules/module.go
@@ -1,3 +1,17 @@
+// Copyright (C) 2024 Jack (jackby03)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
 package modules
 
 import (
@@ -98,3 +112,4 @@ func (s Severity) ScoreWeight() int {
 		return 0
 	}
 }
+

--- a/internal/modules/module_test.go
+++ b/internal/modules/module_test.go
@@ -1,3 +1,17 @@
+// Copyright (C) 2024 Jack (jackby03)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
 package modules
 
 import (
@@ -98,3 +112,4 @@ func TestFinding_IsCompliant(t *testing.T) {
 		})
 	}
 }
+

--- a/internal/modules/mount/checks.go
+++ b/internal/modules/mount/checks.go
@@ -1,3 +1,17 @@
+// Copyright (C) 2024 Jack (jackby03)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
 package mount
 
 import "github.com/hardbox-io/hardbox/internal/modules"
@@ -168,3 +182,4 @@ func kernelModuleChecks() []kernelModuleCheckSpec {
 		},
 	}
 }
+

--- a/internal/modules/mount/export_test.go
+++ b/internal/modules/mount/export_test.go
@@ -1,3 +1,17 @@
+// Copyright (C) 2024 Jack (jackby03)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
 package mount
 
 // Exported shims for white-box testing.
@@ -16,3 +30,4 @@ var (
 	HasInstallFalse  = hasInstallFalse
 	NormaliseModName = normaliseModName
 )
+

--- a/internal/modules/mount/module.go
+++ b/internal/modules/mount/module.go
@@ -1,3 +1,17 @@
+// Copyright (C) 2024 Jack (jackby03)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
 // Package mount implements partition existence and kernel filesystem module checks.
 // It covers dedicated partition checks (mnt-001..mnt-007) and kernel module
 // blacklisting for unused filesystems (mnt-011..mnt-015).
@@ -358,3 +372,4 @@ func (m *Module) Plan(ctx context.Context, _ modules.ModuleConfig) ([]modules.Ch
 		},
 	}}, nil
 }
+

--- a/internal/modules/mount/module_test.go
+++ b/internal/modules/mount/module_test.go
@@ -1,3 +1,17 @@
+// Copyright (C) 2024 Jack (jackby03)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
 package mount_test
 
 import (
@@ -263,3 +277,4 @@ func writeTempFile(t *testing.T, content string) string {
 	}
 	return f.Name()
 }
+

--- a/internal/modules/network/export_test.go
+++ b/internal/modules/network/export_test.go
@@ -1,3 +1,17 @@
+// Copyright (C) 2024 Jack (jackby03)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
 package network
 
 // TestOptions configures module file paths for tests.
@@ -21,3 +35,4 @@ func NewModuleForTest(o TestOptions) *Module {
 		passwdPath:      o.PasswdPath,
 	}
 }
+

--- a/internal/modules/network/module.go
+++ b/internal/modules/network/module.go
@@ -1,3 +1,17 @@
+// Copyright (C) 2024 Jack (jackby03)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
 package network
 
 import (
@@ -411,3 +425,4 @@ func (m *Module) passwdFile() string {
 	}
 	return defaultPasswdPath
 }
+

--- a/internal/modules/network/module_test.go
+++ b/internal/modules/network/module_test.go
@@ -1,3 +1,17 @@
+// Copyright (C) 2024 Jack (jackby03)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
 package network_test
 
 import (
@@ -181,3 +195,4 @@ func assertStatus(t *testing.T, findings []modules.Finding, id string, want modu
 	}
 	t.Fatalf("check %s not found", id)
 }
+

--- a/internal/modules/ntp/export_test.go
+++ b/internal/modules/ntp/export_test.go
@@ -1,3 +1,17 @@
+// Copyright (C) 2024 Jack (jackby03)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
 // export_test.go exposes internal constructor knobs for package-external tests.
 package ntp
 
@@ -13,3 +27,4 @@ func NewModuleForTest(
 		chronyConfPath: chronyPath,
 	}
 }
+

--- a/internal/modules/ntp/module.go
+++ b/internal/modules/ntp/module.go
@@ -1,3 +1,17 @@
+// Copyright (C) 2024 Jack (jackby03)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
 package ntp
 
 import (
@@ -477,3 +491,4 @@ func runCommand(ctx context.Context, name string, args ...string) (string, error
 	}
 	return result, nil
 }
+

--- a/internal/modules/ntp/module_test.go
+++ b/internal/modules/ntp/module_test.go
@@ -1,3 +1,17 @@
+// Copyright (C) 2024 Jack (jackby03)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
 package ntp_test
 
 import (
@@ -200,3 +214,4 @@ func fakeRunner(results map[string]fakeResult) func(context.Context, string, ...
 		return res.out, nil
 	}
 }
+

--- a/internal/modules/services/export_test.go
+++ b/internal/modules/services/export_test.go
@@ -1,3 +1,17 @@
+// Copyright (C) 2024 Jack (jackby03)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
 package services
 
 import "context"
@@ -6,3 +20,4 @@ import "context"
 func NewModuleForTest(run func(ctx context.Context, name string, args ...string) (string, error)) *Module {
 	return &Module{run: run}
 }
+

--- a/internal/modules/services/module.go
+++ b/internal/modules/services/module.go
@@ -1,3 +1,17 @@
+// Copyright (C) 2024 Jack (jackby03)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
 // Package services implements CIS Benchmark 2.x service-state hardening checks.
 // It audits whether unnecessary network services are inactive and disabled,
 // using systemctl to query active and enabled states.
@@ -221,3 +235,4 @@ func (m *Module) Plan(ctx context.Context, cfg modules.ModuleConfig) ([]modules.
 
 	return changes, nil
 }
+

--- a/internal/modules/services/module_test.go
+++ b/internal/modules/services/module_test.go
@@ -1,3 +1,17 @@
+// Copyright (C) 2024 Jack (jackby03)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
 package services_test
 
 import (
@@ -238,3 +252,4 @@ func TestPlan_EmptyWhenAllCompliant(t *testing.T) {
 		t.Errorf("want 0 changes when all compliant, got %d", len(changes))
 	}
 }
+

--- a/internal/modules/ssh/export_test.go
+++ b/internal/modules/ssh/export_test.go
@@ -1,3 +1,17 @@
+// Copyright (C) 2024 Jack (jackby03)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
 package ssh
 
 // ParseSshdConfigForTest exposes parseSshdConfig for use in external test packages.
@@ -9,3 +23,4 @@ func ParseSshdConfigForTest(data []byte) map[string]string {
 func NewModuleForTest(configPath string) *Module {
 	return &Module{configPath: configPath}
 }
+

--- a/internal/modules/ssh/module.go
+++ b/internal/modules/ssh/module.go
@@ -1,3 +1,17 @@
+// Copyright (C) 2024 Jack (jackby03)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
 package ssh
 
 import (
@@ -452,3 +466,4 @@ func setSshdOption(path, key, value string) error {
 
 	return util.AtomicWrite(path, []byte(strings.Join(lines, "\n")), 0600)
 }
+

--- a/internal/modules/ssh/module_test.go
+++ b/internal/modules/ssh/module_test.go
@@ -1,3 +1,17 @@
+// Copyright (C) 2024 Jack (jackby03)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
 package ssh_test
 
 import (
@@ -495,3 +509,4 @@ func assertFileMode(t *testing.T, path string, want os.FileMode) {
 		t.Errorf("file mode: got %04o, want %04o", got, want)
 	}
 }
+

--- a/internal/modules/updates/export_test.go
+++ b/internal/modules/updates/export_test.go
@@ -1,3 +1,17 @@
+// Copyright (C) 2024 Jack (jackby03)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
 package updates
 
 // TestOptions configures file paths and family override for tests.
@@ -27,3 +41,4 @@ func NewModuleForTest(o TestOptions) *Module {
 		dnfAutomaticConfigPath: o.DNFAutomaticConfig,
 	}
 }
+

--- a/internal/modules/updates/module.go
+++ b/internal/modules/updates/module.go
@@ -1,3 +1,17 @@
+// Copyright (C) 2024 Jack (jackby03)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
 package updates
 
 import (
@@ -580,3 +594,4 @@ func dirHasEntries(path string) bool {
 	entries, err := os.ReadDir(path)
 	return err == nil && len(entries) > 0
 }
+

--- a/internal/modules/updates/module_test.go
+++ b/internal/modules/updates/module_test.go
@@ -1,3 +1,17 @@
+// Copyright (C) 2024 Jack (jackby03)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
 package updates_test
 
 import (
@@ -157,3 +171,4 @@ func assertStatus(t *testing.T, findings []modules.Finding, id string, want modu
 	}
 	t.Fatalf("check %s not found", id)
 }
+

--- a/internal/modules/users/checks.go
+++ b/internal/modules/users/checks.go
@@ -1,3 +1,17 @@
+// Copyright (C) 2024 Jack (jackby03)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
 package users
 
 import "github.com/hardbox-io/hardbox/internal/modules"
@@ -266,3 +280,4 @@ func checkUSR017() modules.Check {
 		},
 	}
 }
+

--- a/internal/modules/users/export_test.go
+++ b/internal/modules/users/export_test.go
@@ -1,3 +1,17 @@
+// Copyright (C) 2024 Jack (jackby03)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
 package users
 
 // NewModuleForTest returns a Module with injected paths for white-box testing.
@@ -24,3 +38,4 @@ var SetLoginDefsKey = setLoginDefsKey
 
 // SetSimpleKey exposes the pure helper for unit tests.
 var SetSimpleKey = setSimpleKey
+

--- a/internal/modules/users/module.go
+++ b/internal/modules/users/module.go
@@ -1,3 +1,17 @@
+// Copyright (C) 2024 Jack (jackby03)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
 package users
 
 import (
@@ -774,3 +788,4 @@ func sudoersActiveLineContains(content, token string) bool {
 	}
 	return false
 }
+

--- a/internal/modules/users/module_test.go
+++ b/internal/modules/users/module_test.go
@@ -1,3 +1,17 @@
+// Copyright (C) 2024 Jack (jackby03)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
 package users_test
 
 import (
@@ -301,3 +315,4 @@ func TestPlan_AlreadyCompliant_NoChanges(t *testing.T) {
 		t.Errorf("expected 0 changes when already compliant, got %d", len(changes))
 	}
 }
+

--- a/internal/modules/util/atomicwrite.go
+++ b/internal/modules/util/atomicwrite.go
@@ -1,3 +1,17 @@
+// Copyright (C) 2024 Jack (jackby03)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
 // Package util provides shared helpers for hardbox modules.
 package util
 
@@ -38,3 +52,4 @@ func AtomicWrite(path string, data []byte, mode os.FileMode) error {
 	}
 	return nil
 }
+

--- a/internal/notify/alerter.go
+++ b/internal/notify/alerter.go
@@ -1,3 +1,17 @@
+// Copyright (C) 2024 Jack (jackby03)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
 // Package notify dispatches webhook alerts from the hardbox watch daemon.
 package notify
 
@@ -192,3 +206,4 @@ func matchesFilter(allowed []string, value string) bool {
 	}
 	return false
 }
+

--- a/internal/notify/alerter_test.go
+++ b/internal/notify/alerter_test.go
@@ -1,3 +1,17 @@
+// Copyright (C) 2024 Jack (jackby03)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
 package notify_test
 
 import (
@@ -232,3 +246,4 @@ func TestNotifyRegression_NoRegressions_NoFire(t *testing.T) {
 		t.Errorf("expected 0 payloads when no regressions, got %d", count)
 	}
 }
+

--- a/internal/notify/export_test.go
+++ b/internal/notify/export_test.go
@@ -1,3 +1,17 @@
+// Copyright (C) 2024 Jack (jackby03)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
 package notify
 
 import "context"
@@ -31,3 +45,4 @@ func NewMultiAlerterForTest(sendFn func(AlertPayload) error) *MultiAlerter {
 		adapters: []adapter{&testAdapter{fn: sendFn}},
 	}
 }
+

--- a/internal/notify/slack.go
+++ b/internal/notify/slack.go
@@ -1,3 +1,17 @@
+// Copyright (C) 2024 Jack (jackby03)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
 package notify
 
 import (
@@ -85,3 +99,4 @@ func formatSlackMessage(p AlertPayload) string {
 
 	return strings.TrimRight(sb.String(), "\n")
 }
+

--- a/internal/notify/slack_test.go
+++ b/internal/notify/slack_test.go
@@ -1,3 +1,17 @@
+// Copyright (C) 2024 Jack (jackby03)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
 package notify_test
 
 import (
@@ -96,3 +110,4 @@ func TestFormatSlackMessage_NoScoreDeltaWhenZero(t *testing.T) {
 		t.Error("score delta should not appear when it is 0")
 	}
 }
+

--- a/internal/notify/webhook.go
+++ b/internal/notify/webhook.go
@@ -1,3 +1,17 @@
+// Copyright (C) 2024 Jack (jackby03)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
 package notify
 
 import (
@@ -97,3 +111,4 @@ func retryPost(ctx context.Context, client *http.Client, url string,
 
 	return fmt.Errorf("after %d attempts: %w", retryAttempts, lastErr)
 }
+

--- a/internal/notify/webhook_test.go
+++ b/internal/notify/webhook_test.go
@@ -1,3 +1,17 @@
+// Copyright (C) 2024 Jack (jackby03)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
 package notify_test
 
 import (
@@ -151,3 +165,4 @@ func regressionDiff(_ string) *report.DiffReport {
 		},
 	}
 }
+

--- a/internal/report/diff.go
+++ b/internal/report/diff.go
@@ -1,3 +1,17 @@
+// Copyright (C) 2024 Jack (jackby03)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
 package report
 
 import (
@@ -167,3 +181,4 @@ func sortDiffFindings(findings []DiffFinding) {
 		}
 	}
 }
+

--- a/internal/report/diff_test.go
+++ b/internal/report/diff_test.go
@@ -1,3 +1,17 @@
+// Copyright (C) 2024 Jack (jackby03)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
 package report_test
 
 import (
@@ -255,3 +269,4 @@ func writeTempReportJSON(t *testing.T, dir, name string, r *report.Report) {
 		t.Fatalf("write report file: %v", err)
 	}
 }
+

--- a/internal/report/render_diff_html.go
+++ b/internal/report/render_diff_html.go
@@ -1,3 +1,17 @@
+// Copyright (C) 2024 Jack (jackby03)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
 package report
 
 import (
@@ -151,3 +165,4 @@ func renderDiffHTML(d *DiffReport, w io.Writer) error {
 </body></html>`, html.EscapeString(time.Now().UTC().Format("2006")))
 	return err
 }
+

--- a/internal/report/render_diff_text.go
+++ b/internal/report/render_diff_text.go
@@ -1,3 +1,17 @@
+// Copyright (C) 2024 Jack (jackby03)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
 package report
 
 import (
@@ -121,3 +135,4 @@ func writeDiffFindingTable(w io.Writer, findings []DiffFinding) error {
 	}
 	return nil
 }
+

--- a/internal/report/render_html.go
+++ b/internal/report/render_html.go
@@ -1,3 +1,17 @@
+// Copyright (C) 2024 Jack (jackby03)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
 package report
 
 import (
@@ -219,3 +233,4 @@ func htmlSeverityClass(severity string) string {
 		return "sev-info"
 	}
 }
+

--- a/internal/report/render_html_test.go
+++ b/internal/report/render_html_test.go
@@ -1,3 +1,17 @@
+// Copyright (C) 2024 Jack (jackby03)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
 package report_test
 
 import (
@@ -93,3 +107,4 @@ func TestWrite_HTML_XSSEscaping(t *testing.T) {
 		t.Error("HTML output should contain HTML-escaped onerror content as safe text")
 	}
 }
+

--- a/internal/report/render_json.go
+++ b/internal/report/render_json.go
@@ -1,3 +1,17 @@
+// Copyright (C) 2024 Jack (jackby03)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
 package report
 
 import (
@@ -10,3 +24,4 @@ func renderJSON(v any, w io.Writer) error {
 	enc.SetIndent("", "  ")
 	return enc.Encode(v)
 }
+

--- a/internal/report/render_markdown.go
+++ b/internal/report/render_markdown.go
@@ -1,3 +1,17 @@
+// Copyright (C) 2024 Jack (jackby03)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
 package report
 
 import (
@@ -73,3 +87,4 @@ func mdStatusBadge(status string) string {
 		return "🚨 " + status
 	}
 }
+

--- a/internal/report/render_text.go
+++ b/internal/report/render_text.go
@@ -1,3 +1,17 @@
+// Copyright (C) 2024 Jack (jackby03)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
 package report
 
 import (
@@ -81,3 +95,4 @@ func countFindings(r *Report) (compliant, total int) {
 	}
 	return
 }
+

--- a/internal/report/render_text_test.go
+++ b/internal/report/render_text_test.go
@@ -1,3 +1,17 @@
+// Copyright (C) 2024 Jack (jackby03)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
 package report
 
 import (
@@ -162,3 +176,4 @@ func TestRenderText_WriteErrors(t *testing.T) {
 		})
 	}
 }
+

--- a/internal/report/report.go
+++ b/internal/report/report.go
@@ -1,3 +1,17 @@
+// Copyright (C) 2024 Jack (jackby03)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
 // Package report builds and renders hardbox audit reports in multiple formats.
 package report
 
@@ -156,3 +170,4 @@ func severityWeight(s modules.Severity) int {
 		return 0
 	}
 }
+

--- a/internal/report/report_test.go
+++ b/internal/report/report_test.go
@@ -1,3 +1,17 @@
+// Copyright (C) 2024 Jack (jackby03)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
 package report_test
 
 import (
@@ -259,3 +273,4 @@ func TestWrite_UnknownFormat_FallsBackToText(t *testing.T) {
 		t.Error("fallback text output should contain warning about unknown format")
 	}
 }
+

--- a/internal/sdk/loader.go
+++ b/internal/sdk/loader.go
@@ -1,3 +1,17 @@
+// Copyright (C) 2024 Jack (jackby03)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
 //go:build linux || darwin || freebsd
 
 package sdk
@@ -70,3 +84,4 @@ func loadPlugin(path string) (modules.Module, error) {
 
 	return newFn(), nil
 }
+

--- a/internal/sdk/loader_unsupported.go
+++ b/internal/sdk/loader_unsupported.go
@@ -1,3 +1,17 @@
+// Copyright (C) 2024 Jack (jackby03)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
 //go:build !linux && !darwin && !freebsd
 
 package sdk
@@ -10,3 +24,4 @@ import "fmt"
 func LoadPlugins(_ string) ([]PluginEntry, error) {
 	return nil, fmt.Errorf("plugin loading is not supported on this platform (requires Linux, macOS, or FreeBSD)")
 }
+

--- a/internal/sdk/module.go
+++ b/internal/sdk/module.go
@@ -1,3 +1,17 @@
+// Copyright (C) 2024 Jack (jackby03)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
 // Package sdk exposes the stable public interface for hardbox plugin authors.
 // Import this package to implement a custom hardening module that can be loaded
 // into hardbox at runtime without forking the core.
@@ -83,3 +97,4 @@ type PluginEntry struct {
 	Path   string
 	Module modules.Module
 }
+

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -1,3 +1,17 @@
+// Copyright (C) 2024 Jack (jackby03)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
 // Package serve implements the hardbox web dashboard HTTP server.
 package serve
 
@@ -241,3 +255,4 @@ func (s *Server) render(w http.ResponseWriter, name string, data any) {
 		http.Error(w, "render error: "+err.Error(), http.StatusInternalServerError)
 	}
 }
+

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -1,3 +1,17 @@
+// Copyright (C) 2024 Jack (jackby03)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
 package tui
 
 import (
@@ -186,3 +200,4 @@ func (a App) View() string {
 		return lipgloss.NewStyle().Padding(1, 2).Render("Loading...")
 	}
 }
+

--- a/internal/tui/dashboard.go
+++ b/internal/tui/dashboard.go
@@ -1,3 +1,17 @@
+// Copyright (C) 2024 Jack (jackby03)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
 package tui
 
 import (
@@ -108,3 +122,4 @@ func styles() styleSet {
 			MarginTop(1),
 	}
 }
+

--- a/internal/tui/moduledetail.go
+++ b/internal/tui/moduledetail.go
@@ -1,3 +1,17 @@
+// Copyright (C) 2024 Jack (jackby03)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
 package tui
 
 import (
@@ -208,3 +222,4 @@ func truncate(s string, maxLen int) string {
 	}
 	return string(runes[:maxLen-1]) + "…"
 }
+

--- a/internal/tui/modules.go
+++ b/internal/tui/modules.go
@@ -1,3 +1,17 @@
+// Copyright (C) 2024 Jack (jackby03)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
 package tui
 
 import (
@@ -77,3 +91,4 @@ func (m modulesModel) View() string {
 		s.panel.Render(body),
 	)
 }
+

--- a/internal/tui/workflow.go
+++ b/internal/tui/workflow.go
@@ -1,3 +1,17 @@
+// Copyright (C) 2024 Jack (jackby03)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
 package tui
 
 import (
@@ -495,3 +509,4 @@ func estimateRisk(totalChanges int) string {
 		return "low"
 	}
 }
+

--- a/terraform-provider/internal/hardbox/install.go
+++ b/terraform-provider/internal/hardbox/install.go
@@ -1,3 +1,17 @@
+// Copyright (C) 2024 Jack (jackby03)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
 package hardbox
 
 import (
@@ -149,3 +163,4 @@ func ParseFindings(reportContent, format string) map[string]string {
 	result["info"] = strconv.Itoa(report.Summary.Info)
 	return result
 }
+

--- a/terraform-provider/internal/hardbox/ssh.go
+++ b/terraform-provider/internal/hardbox/ssh.go
@@ -1,3 +1,17 @@
+// Copyright (C) 2024 Jack (jackby03)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
 // Package hardbox provides SSH utilities and hardbox CLI helpers
 // used by the Terraform provider resource implementation.
 package hardbox
@@ -182,3 +196,4 @@ func (c *SSHClient) ReadFile(path string) (string, error) {
 func (c *SSHClient) Close() error {
 	return c.client.Close()
 }
+

--- a/terraform-provider/internal/provider/provider.go
+++ b/terraform-provider/internal/provider/provider.go
@@ -1,3 +1,17 @@
+// Copyright (C) 2024 Jack (jackby03)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
 // Package provider implements the hardbox Terraform provider.
 // The provider exposes a single resource — hardbox_apply — which provisions
 // a remote Linux host using the hardbox hardening CLI.
@@ -92,3 +106,4 @@ func (p *hardboxProvider) DataSources(_ context.Context) []func() datasource.Dat
 func (p *hardboxProvider) Functions(_ context.Context) []func() function.Function {
 	return []func() function.Function{}
 }
+

--- a/terraform-provider/internal/provider/resource_hardbox_apply.go
+++ b/terraform-provider/internal/provider/resource_hardbox_apply.go
@@ -1,3 +1,17 @@
+// Copyright (C) 2024 Jack (jackby03)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
 package provider
 
 import (
@@ -400,3 +414,4 @@ func (r *hardboxApplyResource) applyHardening(
 	}
 	m.Findings, _ = types.MapValue(types.StringType, findingsMap)
 }
+

--- a/terraform-provider/main.go
+++ b/terraform-provider/main.go
@@ -1,3 +1,17 @@
+// Copyright (C) 2024 Jack (jackby03)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
 // Package main is the entrypoint for the hardbox Terraform provider.
 // Build with: go build -o terraform-provider-hardbox .
 package main
@@ -31,3 +45,4 @@ func main() {
 		log.Fatal(err)
 	}
 }
+


### PR DESCRIPTION
## Summary
Previously licensed under MIT. Re-licensed to GNU Affero General Public License v3 to protect against SaaS exploitation and support a future dual-licensing model.

### Changes Included:
1. Replaced \LICENSE\ file with official AGPL v3 text.
2. Added \NOTICE\ file recording the transition from MIT to AGPL v3.
3. Injected the official AGPL v3 header block into **all** \.go\ source files.
4. Updated references in \README.md\, \ROADMAP.md\, \CONTRIBUTING.md\, \nsible-role/hardbox/README.md\, \nsible-role/hardbox/meta/main.yml\, and \.github/copilot-instructions.md\.
5. Created Git tag \0.x.0-agpl\ to demarcate the licensing epoch.

All copyright retained by Jack (jackby03).