### PR TITLE
🧹 refactor(modules): consolidate complianceStatus to shared package

### DIFF
--- a/internal/modules/mac/module.go
+++ b/internal/modules/mac/module.go
@@ -143,9 +143,9 @@ func (m *Module) auditAppArmor(ctx context.Context) ([]modules.Finding, error) {
 
 	return []modules.Finding{
 		{Check: checkMAC001(), Status: modules.StatusCompliant, Current: "aa-status available", Target: "installed", Detail: "AppArmor userspace tooling detected"},
-		{Check: checkMAC002(), Status: complianceStatus(enabled), Current: boolLabel(enabled), Target: "enabled", Detail: "read /sys/module/apparmor/parameters/enabled"},
-		{Check: checkMAC003(), Status: complianceStatus(enforcing), Current: fmt.Sprintf("%d profiles enforcing", parseAANumber(out, "profiles are in enforce mode")), Target: ">= 1 enforcing profile", Detail: "parsed aa-status output"},
-		{Check: checkMAC004(), Status: complianceStatus(unconfined == 0), Current: fmt.Sprintf("%d unconfined", unconfined), Target: "0", Detail: "parsed aa-status output"},
+		{Check: checkMAC002(), Status: modules.ComplianceStatus(enabled), Current: boolLabel(enabled), Target: "enabled", Detail: "read /sys/module/apparmor/parameters/enabled"},
+		{Check: checkMAC003(), Status: modules.ComplianceStatus(enforcing), Current: fmt.Sprintf("%d profiles enforcing", parseAANumber(out, "profiles are in enforce mode")), Target: ">= 1 enforcing profile", Detail: "parsed aa-status output"},
+		{Check: checkMAC004(), Status: modules.ComplianceStatus(unconfined == 0), Current: fmt.Sprintf("%d unconfined", unconfined), Target: "0", Detail: "parsed aa-status output"},
 		newSkipped(checkMAC005(), "n/a", "targeted or mls", "SELinux-only check"),
 	}, nil
 }
@@ -179,10 +179,10 @@ func (m *Module) auditSELinux(ctx context.Context) ([]modules.Finding, error) {
 
 	return []modules.Finding{
 		{Check: checkMAC001(), Status: modules.StatusCompliant, Current: "sestatus available", Target: "installed", Detail: "SELinux userspace tooling detected"},
-		{Check: checkMAC002(), Status: complianceStatus(enabled), Current: valueOrUnknown(boolLabel(enabled), status == ""), Target: "enabled", Detail: fmt.Sprintf("SELinux status=%q, config SELINUX=%q", status, cfgMode)},
-		{Check: checkMAC003(), Status: complianceStatus(enforcing), Current: valueOrUnknown(currentMode, currentMode == ""), Target: "enforcing", Detail: "parsed sestatus output"},
+		{Check: checkMAC002(), Status: modules.ComplianceStatus(enabled), Current: valueOrUnknown(boolLabel(enabled), status == ""), Target: "enabled", Detail: fmt.Sprintf("SELinux status=%q, config SELINUX=%q", status, cfgMode)},
+		{Check: checkMAC003(), Status: modules.ComplianceStatus(enforcing), Current: valueOrUnknown(currentMode, currentMode == ""), Target: "enforcing", Detail: "parsed sestatus output"},
 		newSkipped(checkMAC004(), "n/a", "0", "AppArmor-only check"),
-		{Check: checkMAC005(), Status: complianceStatus(policyOk), Current: valueOrUnknown(policy, policy == ""), Target: "targeted or mls", Detail: fmt.Sprintf("SELINUXTYPE=%q", cfgType)},
+		{Check: checkMAC005(), Status: modules.ComplianceStatus(policyOk), Current: valueOrUnknown(policy, policy == ""), Target: "targeted or mls", Detail: fmt.Sprintf("SELINUXTYPE=%q", cfgType)},
 	}, nil
 }
 
@@ -279,13 +279,6 @@ func readSELinuxConfig(path string) map[string]string {
 	return out
 }
 
-func complianceStatus(ok bool) modules.Status {
-	if ok {
-		return modules.StatusCompliant
-	}
-	return modules.StatusNonCompliant
-}
-
 func boolLabel(v bool) string {
 	if v {
 		return "enabled"
@@ -314,4 +307,3 @@ func cfgString(cfg modules.ModuleConfig, key, fallback string) string {
 func newSkipped(chk modules.Check, current, target, detail string) modules.Finding {
 	return modules.Finding{Check: chk, Status: modules.StatusSkipped, Current: current, Target: target, Detail: detail}
 }
-

--- a/internal/modules/module.go
+++ b/internal/modules/module.go
@@ -113,3 +113,10 @@ func (s Severity) ScoreWeight() int {
 	}
 }
 
+// ComplianceStatus converts a boolean to a Status.
+func ComplianceStatus(ok bool) Status {
+	if ok {
+		return StatusCompliant
+	}
+	return StatusNonCompliant
+}

--- a/internal/modules/network/module.go
+++ b/internal/modules/network/module.go
@@ -150,7 +150,7 @@ func (m *Module) auditIPv6(cfg modules.ModuleConfig) modules.Finding {
 	if !disableIPv6 {
 		return modules.Finding{Check: chk, Status: modules.StatusManual, Current: val, Target: "disabled when not used", Detail: "profile does not require disabling IPv6"}
 	}
-	return modules.Finding{Check: chk, Status: complianceStatus(val == "1"), Current: val, Target: "1", Detail: "read net.ipv6.conf.all.disable_ipv6"}
+	return modules.Finding{Check: chk, Status: modules.ComplianceStatus(val == "1"), Current: val, Target: "1", Detail: "read net.ipv6.conf.all.disable_ipv6"}
 }
 
 func (m *Module) auditBlacklistedModule(c moduleCheck, cfg modules.ModuleConfig) modules.Finding {
@@ -207,7 +207,7 @@ func (m *Module) auditWireless(cfg modules.ModuleConfig) modules.Finding {
 			ifaces++
 		}
 	}
-	return modules.Finding{Check: chk, Status: complianceStatus(ifaces == 0), Current: fmt.Sprintf("%d interfaces", ifaces), Target: "0 interfaces", Detail: "parsed /proc/net/wireless"}
+	return modules.Finding{Check: chk, Status: modules.ComplianceStatus(ifaces == 0), Current: fmt.Sprintf("%d interfaces", ifaces), Target: "0 interfaces", Detail: "parsed /proc/net/wireless"}
 }
 
 func (m *Module) auditTCPWrappers() modules.Finding {
@@ -223,7 +223,7 @@ func (m *Module) auditTCPWrappers() modules.Finding {
 		return modules.Finding{Check: chk, Status: modules.StatusNonCompliant, Current: "missing files", Target: "both configured", Detail: "hosts.allow and hosts.deny must exist and be non-empty"}
 	}
 	ok := allow != "" && deny != ""
-	return modules.Finding{Check: chk, Status: complianceStatus(ok), Current: fmt.Sprintf("allow=%t deny=%t", allow != "", deny != ""), Target: "both non-empty", Detail: "basic TCP wrappers presence check"}
+	return modules.Finding{Check: chk, Status: modules.ComplianceStatus(ok), Current: fmt.Sprintf("allow=%t deny=%t", allow != "", deny != ""), Target: "both non-empty", Detail: "basic TCP wrappers presence check"}
 }
 
 func (m *Module) auditHomeSecrets() modules.Finding {
@@ -368,13 +368,6 @@ func cfgBool(cfg modules.ModuleConfig, key string, fallback bool) bool {
 	return fallback
 }
 
-func complianceStatus(ok bool) modules.Status {
-	if ok {
-		return modules.StatusCompliant
-	}
-	return modules.StatusNonCompliant
-}
-
 func isFindingCompliant(findings []modules.Finding, checkID string) bool {
 	for _, f := range findings {
 		if f.Check.ID == checkID {
@@ -425,4 +418,3 @@ func (m *Module) passwdFile() string {
 	}
 	return defaultPasswdPath
 }
-

--- a/internal/modules/ntp/module.go
+++ b/internal/modules/ntp/module.go
@@ -83,14 +83,14 @@ func (m *Module) Audit(ctx context.Context, cfg modules.ModuleConfig) ([]modules
 	findings := make([]modules.Finding, 0, 5)
 	findings = append(findings, modules.Finding{
 		Check:   checkNTP001(),
-		Status:  complianceStatus(installedCount > 0),
+		Status:  modules.ComplianceStatus(installedCount > 0),
 		Current: fmt.Sprintf("%d detected", installedCount),
 		Target:  "at least 1 (chronyd/systemd-timesyncd/ntpd)",
 		Detail:  fmt.Sprintf("installed services: %s", installedServices(services)),
 	})
 	findings = append(findings, modules.Finding{
 		Check:   checkNTP002(),
-		Status:  complianceStatus(activeCount == 1),
+		Status:  modules.ComplianceStatus(activeCount == 1),
 		Current: fmt.Sprintf("%d active", activeCount),
 		Target:  "exactly 1 active service",
 		Detail:  fmt.Sprintf("active services: %s", activeServices(services)),
@@ -111,7 +111,7 @@ func (m *Module) Audit(ctx context.Context, cfg modules.ModuleConfig) ([]modules
 	tzStatus := modules.StatusError
 	tzDetail := "failed to read timezone"
 	if tzErr == nil {
-		tzStatus = complianceStatus(timezoneMatches(tzCurrent, tzTarget))
+		tzStatus = modules.ComplianceStatus(timezoneMatches(tzCurrent, tzTarget))
 		tzDetail = fmt.Sprintf("current timezone: %q", tzCurrent)
 	}
 	findings = append(findings, modules.Finding{
@@ -345,13 +345,6 @@ func checkNTP005() modules.Check {
 	}
 }
 
-func complianceStatus(ok bool) modules.Status {
-	if ok {
-		return modules.StatusCompliant
-	}
-	return modules.StatusNonCompliant
-}
-
 func installedServices(states []serviceState) string {
 	var out []string
 	for _, s := range states {
@@ -491,4 +484,3 @@ func runCommand(ctx context.Context, name string, args ...string) (string, error
 	}
 	return result, nil
 }
-

--- a/internal/modules/updates/module.go
+++ b/internal/modules/updates/module.go
@@ -149,7 +149,7 @@ func (m *Module) auditSecurityRepo(family string) modules.Finding {
 		hasSecurity, detail := hasDebianSecurityRepo(m.aptSourcesPath(), m.aptSourcesDirPath())
 		return modules.Finding{
 			Check:   checkUPD002(),
-			Status:  complianceStatus(hasSecurity),
+			Status:  modules.ComplianceStatus(hasSecurity),
 			Current: detail,
 			Target:  "security repository enabled",
 			Detail:  "parsed apt sources for security repositories",
@@ -163,7 +163,7 @@ func (m *Module) auditSecurityRepo(family string) modules.Finding {
 		ok := upgradeType == "security"
 		return modules.Finding{
 			Check:   checkUPD002(),
-			Status:  complianceStatus(ok),
+			Status:  modules.ComplianceStatus(ok),
 			Current: valueOrMissing(upgradeType),
 			Target:  "security",
 			Detail:  "dnf-automatic upgrade_type should be security",
@@ -184,7 +184,7 @@ func (m *Module) auditUnattended(family string) modules.Finding {
 		ok := val == "1"
 		return modules.Finding{
 			Check:   checkUPD003(),
-			Status:  complianceStatus(ok),
+			Status:  modules.ComplianceStatus(ok),
 			Current: valueOrMissing(val),
 			Target:  "1",
 			Detail:  "APT::Periodic::Unattended-Upgrade must be enabled",
@@ -198,7 +198,7 @@ func (m *Module) auditUnattended(family string) modules.Finding {
 		ok := val == "yes" || val == "true" || val == "1"
 		return modules.Finding{
 			Check:   checkUPD003(),
-			Status:  complianceStatus(ok),
+			Status:  modules.ComplianceStatus(ok),
 			Current: valueOrMissing(val),
 			Target:  "yes",
 			Detail:  "dnf-automatic apply_updates should be enabled",
@@ -224,7 +224,7 @@ func (m *Module) auditAutoReboot(family string, targetEnabled bool) modules.Find
 		currentEnabled := current == "true" || current == "1" || current == "yes"
 		return modules.Finding{
 			Check:   checkUPD004(),
-			Status:  complianceStatus(currentEnabled == targetEnabled),
+			Status:  modules.ComplianceStatus(currentEnabled == targetEnabled),
 			Current: boolLabel(currentEnabled),
 			Target:  target,
 			Detail:  "Unattended-Upgrade::Automatic-Reboot is configurable via module config",
@@ -238,7 +238,7 @@ func (m *Module) auditAutoReboot(family string, targetEnabled bool) modules.Find
 		currentEnabled := current == "when-needed" || current == "yes" || current == "true" || current == "1"
 		return modules.Finding{
 			Check:   checkUPD004(),
-			Status:  complianceStatus(currentEnabled == targetEnabled),
+			Status:  modules.ComplianceStatus(currentEnabled == targetEnabled),
 			Current: boolLabel(currentEnabled),
 			Target:  target,
 			Detail:  "dnf-automatic reboot should match module config",
@@ -533,13 +533,6 @@ func expandPath(pattern string) []string {
 	return []string{pattern}
 }
 
-func complianceStatus(ok bool) modules.Status {
-	if ok {
-		return modules.StatusCompliant
-	}
-	return modules.StatusNonCompliant
-}
-
 func boolLabel(v bool) string {
 	if v {
 		return "enabled"
@@ -594,4 +587,3 @@ func dirHasEntries(path string) bool {
 	entries, err := os.ReadDir(path)
 	return err == nil && len(entries) > 0
 }
-


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
The `complianceStatus` function was duplicated across multiple modules (`mac`, `network`, `ntp`, `updates`). This PR moves the function into `internal/modules/module.go` as `ComplianceStatus` and updates all usages.

💡 **Why:** How this improves maintainability
This refactoring removes duplicate code, ensuring that the logic for mapping booleans to compliance statuses is consistent across the codebase and located in a single, shared place.

✅ **Verification:** How you confirmed the change is safe
Ran `make test` which passes for all modules, and visually verified no side effects were introduced. The change is purely a move and rename.

✨ **Result:** The improvement achieved
A cleaner and more maintainable codebase, ready to be expanded upon without needing to duplicate small utility functions across every module.

---
*PR created automatically by Jules for task [12140775391344277581](https://jules.google.com/task/12140775391344277581) started by @jackby03*