### PR TITLE
🧹 refactor(test): consolidate testdataPath helper

### DIFF
--- a/internal/modules/auditd/module_test.go
+++ b/internal/modules/auditd/module_test.go
@@ -16,6 +16,7 @@ package auditd_test
 
 import (
 	"context"
+	"github.com/hardbox-io/hardbox/internal/modules/util/testutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -73,10 +74,6 @@ func assertStatus(t *testing.T, findings []modules.Finding, id string, want modu
 	t.Errorf("check %s: not found in findings", id)
 }
 
-func testdataPath(elem ...string) string {
-	return filepath.Join(append([]string{"testdata"}, elem...)...)
-}
-
 // ── interface ─────────────────────────────────────────────────────────────────
 
 func TestModule_ImplementsInterface(t *testing.T) {
@@ -98,8 +95,8 @@ func TestModule_NameAndVersion(t *testing.T) {
 func TestAudit_AllCompliant(t *testing.T) {
 	m := auditd.NewModuleForTest(
 		fakeRunner(serviceEnabled()),
-		testdataPath("rules_hardened"),
-		testdataPath("auditd_conf_hardened"),
+		testutil.TestdataPath("rules_hardened"),
+		testutil.TestdataPath("auditd_conf_hardened"),
 	)
 
 	findings, err := m.Audit(context.Background(), nil)
@@ -121,8 +118,8 @@ func TestAudit_AllCompliant(t *testing.T) {
 func TestAudit_DefaultRules_RuleChecksNonCompliant(t *testing.T) {
 	m := auditd.NewModuleForTest(
 		fakeRunner(serviceEnabled()),
-		testdataPath("rules_default"),
-		testdataPath("auditd_conf_hardened"),
+		testutil.TestdataPath("rules_default"),
+		testutil.TestdataPath("auditd_conf_hardened"),
 	)
 
 	findings, err := m.Audit(context.Background(), nil)
@@ -146,8 +143,8 @@ func TestAudit_DefaultRules_RuleChecksNonCompliant(t *testing.T) {
 func TestAudit_DefaultConf_ConfChecksNonCompliant(t *testing.T) {
 	m := auditd.NewModuleForTest(
 		fakeRunner(serviceEnabled()),
-		testdataPath("rules_hardened"),
-		testdataPath("auditd_conf_default"),
+		testutil.TestdataPath("rules_hardened"),
+		testutil.TestdataPath("auditd_conf_default"),
 	)
 
 	findings, err := m.Audit(context.Background(), nil)
@@ -166,8 +163,8 @@ func TestAudit_DefaultConf_ConfChecksNonCompliant(t *testing.T) {
 func TestAudit_ServiceDisabled_AUD013NonCompliant(t *testing.T) {
 	m := auditd.NewModuleForTest(
 		fakeRunner(serviceDisabled()),
-		testdataPath("rules_hardened"),
-		testdataPath("auditd_conf_hardened"),
+		testutil.TestdataPath("rules_hardened"),
+		testutil.TestdataPath("auditd_conf_hardened"),
 	)
 
 	findings, err := m.Audit(context.Background(), nil)
@@ -182,8 +179,8 @@ func TestAudit_ServiceDisabled_AUD013NonCompliant(t *testing.T) {
 func TestAudit_MissingRulesDir_AllRuleChecksNonCompliant(t *testing.T) {
 	m := auditd.NewModuleForTest(
 		fakeRunner(serviceEnabled()),
-		testdataPath("rules_nonexistent"),
-		testdataPath("auditd_conf_hardened"),
+		testutil.TestdataPath("rules_nonexistent"),
+		testutil.TestdataPath("auditd_conf_hardened"),
 	)
 
 	findings, err := m.Audit(context.Background(), nil)
@@ -200,7 +197,7 @@ func TestAudit_MissingRulesDir_AllRuleChecksNonCompliant(t *testing.T) {
 func TestPlan_WritesRulesFile(t *testing.T) {
 	dir := t.TempDir()
 	rulesDir := filepath.Join(dir, "rules.d")
-	confPath := testdataPath("auditd_conf_hardened")
+	confPath := testutil.TestdataPath("auditd_conf_hardened")
 
 	m := auditd.NewModuleForTest(
 		fakeRunner(serviceEnabled()),
@@ -248,7 +245,7 @@ func TestPlan_AlreadyCompliant_NoChanges(t *testing.T) {
 	m := auditd.NewModuleForTest(
 		fakeRunner(serviceEnabled()),
 		rulesDir,
-		testdataPath("auditd_conf_hardened"),
+		testutil.TestdataPath("auditd_conf_hardened"),
 	)
 
 	changes, err := m.Plan(context.Background(), nil)
@@ -270,7 +267,7 @@ func TestPlan_ApplyRevert(t *testing.T) {
 	m := auditd.NewModuleForTest(
 		fakeRunner(serviceEnabled()),
 		rulesDir,
-		testdataPath("auditd_conf_hardened"),
+		testutil.TestdataPath("auditd_conf_hardened"),
 	)
 
 	changes, err := m.Plan(context.Background(), nil)
@@ -297,4 +294,3 @@ func TestPlan_ApplyRevert(t *testing.T) {
 		t.Error("expected rules file to be removed after Revert()")
 	}
 }
-

--- a/internal/modules/containers/module_test.go
+++ b/internal/modules/containers/module_test.go
@@ -16,8 +16,8 @@ package containers_test
 
 import (
 	"context"
+	"github.com/hardbox-io/hardbox/internal/modules/util/testutil"
 	"os"
-	"path/filepath"
 	"strings"
 	"testing"
 
@@ -68,16 +68,6 @@ func assertStatus(t *testing.T, findings []modules.Finding, id string, want modu
 		}
 	}
 	t.Errorf("check %s: not found in %d findings", id, len(findings))
-}
-
-// testdataPath returns the absolute path to a file in testdata/.
-func testdataPath(t *testing.T, name string) string {
-	t.Helper()
-	p, err := filepath.Abs(filepath.Join("testdata", name))
-	if err != nil {
-		t.Fatalf("testdataPath(%q): %v", name, err)
-	}
-	return p
 }
 
 // emptyAuditDir creates a temporary directory with no .rules files.
@@ -154,8 +144,8 @@ func TestAudit_RootlessCompliant(t *testing.T) {
 			"docker ps -q": {out: ""},
 		}),
 		alwaysHasDocker,
-		testdataPath(t, "daemon_hardened.json"),
-		testdataPath(t, "audit_rules"),
+		testutil.TestdataAbsPath(t, "daemon_hardened.json"),
+		testutil.TestdataAbsPath(t, "audit_rules"),
 	)
 	findings, err := m.Audit(context.Background(), nil)
 	if err != nil {
@@ -171,8 +161,8 @@ func TestAudit_RootlessNonCompliant(t *testing.T) {
 			"docker ps -q": {out: ""},
 		}),
 		alwaysHasDocker,
-		testdataPath(t, "daemon_hardened.json"),
-		testdataPath(t, "audit_rules"),
+		testutil.TestdataAbsPath(t, "daemon_hardened.json"),
+		testutil.TestdataAbsPath(t, "audit_rules"),
 	)
 	findings, err := m.Audit(context.Background(), nil)
 	if err != nil {
@@ -192,7 +182,7 @@ func TestAudit_ICCCompliant(t *testing.T) {
 			"docker ps -q": {out: ""},
 		}),
 		alwaysHasDocker,
-		testdataPath(t, "daemon_hardened.json"),
+		testutil.TestdataAbsPath(t, "daemon_hardened.json"),
 		emptyAuditDir(t),
 	)
 	findings, err := m.Audit(context.Background(), nil)
@@ -209,7 +199,7 @@ func TestAudit_ICCNonCompliant(t *testing.T) {
 			"docker ps -q": {out: ""},
 		}),
 		alwaysHasDocker,
-		testdataPath(t, "daemon_default.json"),
+		testutil.TestdataAbsPath(t, "daemon_default.json"),
 		emptyAuditDir(t),
 	)
 	findings, err := m.Audit(context.Background(), nil)
@@ -230,7 +220,7 @@ func TestAudit_UsernsRemapCompliant(t *testing.T) {
 			"docker ps -q": {out: ""},
 		}),
 		alwaysHasDocker,
-		testdataPath(t, "daemon_hardened.json"),
+		testutil.TestdataAbsPath(t, "daemon_hardened.json"),
 		emptyAuditDir(t),
 	)
 	findings, err := m.Audit(context.Background(), nil)
@@ -247,7 +237,7 @@ func TestAudit_UsernsRemapNonCompliant(t *testing.T) {
 			"docker ps -q": {out: ""},
 		}),
 		alwaysHasDocker,
-		testdataPath(t, "daemon_default.json"),
+		testutil.TestdataAbsPath(t, "daemon_default.json"),
 		emptyAuditDir(t),
 	)
 	findings, err := m.Audit(context.Background(), nil)
@@ -269,7 +259,7 @@ func TestAudit_TLSSkippedNoTCPHost(t *testing.T) {
 			"docker ps -q": {out: ""},
 		}),
 		alwaysHasDocker,
-		testdataPath(t, "daemon_hardened.json"),
+		testutil.TestdataAbsPath(t, "daemon_hardened.json"),
 		emptyAuditDir(t),
 	)
 	findings, err := m.Audit(context.Background(), nil)
@@ -287,7 +277,7 @@ func TestAudit_TLSNonCompliantOnTCPHost(t *testing.T) {
 			"docker ps -q": {out: ""},
 		}),
 		alwaysHasDocker,
-		testdataPath(t, "daemon_tcp_no_tls.json"),
+		testutil.TestdataAbsPath(t, "daemon_tcp_no_tls.json"),
 		emptyAuditDir(t),
 	)
 	findings, err := m.Audit(context.Background(), nil)
@@ -308,7 +298,7 @@ func TestAudit_SeccompAndMACNonCompliant(t *testing.T) {
 			"docker ps -q": {out: ""},
 		}),
 		alwaysHasDocker,
-		testdataPath(t, "daemon_default.json"),
+		testutil.TestdataAbsPath(t, "daemon_default.json"),
 		emptyAuditDir(t),
 	)
 	findings, err := m.Audit(context.Background(), nil)
@@ -326,7 +316,7 @@ func TestAudit_SeccompAndMACCompliant(t *testing.T) {
 			"docker ps -q": {out: ""},
 		}),
 		alwaysHasDocker,
-		testdataPath(t, "daemon_default.json"),
+		testutil.TestdataAbsPath(t, "daemon_default.json"),
 		emptyAuditDir(t),
 	)
 	findings, err := m.Audit(context.Background(), nil)
@@ -350,7 +340,7 @@ func TestAudit_PrivilegedContainerFound(t *testing.T) {
 			inspectKey:     {out: "true"},
 		}),
 		alwaysHasDocker,
-		testdataPath(t, "daemon_default.json"),
+		testutil.TestdataAbsPath(t, "daemon_default.json"),
 		emptyAuditDir(t),
 	)
 	findings, err := m.Audit(context.Background(), nil)
@@ -369,7 +359,7 @@ func TestAudit_NoPrivilegedContainers(t *testing.T) {
 			inspectKey:     {out: "false"},
 		}),
 		alwaysHasDocker,
-		testdataPath(t, "daemon_default.json"),
+		testutil.TestdataAbsPath(t, "daemon_default.json"),
 		emptyAuditDir(t),
 	)
 	findings, err := m.Audit(context.Background(), nil)
@@ -394,7 +384,7 @@ func TestAudit_SocketMountFound(t *testing.T) {
 			mntKey:         {out: "/var/run/docker.sock /home/user/data "},
 		}),
 		alwaysHasDocker,
-		testdataPath(t, "daemon_default.json"),
+		testutil.TestdataAbsPath(t, "daemon_default.json"),
 		emptyAuditDir(t),
 	)
 	findings, err := m.Audit(context.Background(), nil)
@@ -415,7 +405,7 @@ func TestAudit_NoSocketMount(t *testing.T) {
 			mntKey:         {out: "/home/user/data "},
 		}),
 		alwaysHasDocker,
-		testdataPath(t, "daemon_default.json"),
+		testutil.TestdataAbsPath(t, "daemon_default.json"),
 		emptyAuditDir(t),
 	)
 	findings, err := m.Audit(context.Background(), nil)
@@ -436,7 +426,7 @@ func TestAudit_ImageScanningAlwaysManual(t *testing.T) {
 			"docker ps -q": {out: ""},
 		}),
 		alwaysHasDocker,
-		testdataPath(t, "daemon_default.json"),
+		testutil.TestdataAbsPath(t, "daemon_default.json"),
 		emptyAuditDir(t),
 	)
 	findings, err := m.Audit(context.Background(), nil)
@@ -457,8 +447,8 @@ func TestAudit_AuditRulePresent(t *testing.T) {
 			"docker ps -q": {out: ""},
 		}),
 		alwaysHasDocker,
-		testdataPath(t, "daemon_default.json"),
-		testdataPath(t, "audit_rules"),
+		testutil.TestdataAbsPath(t, "daemon_default.json"),
+		testutil.TestdataAbsPath(t, "audit_rules"),
 	)
 	findings, err := m.Audit(context.Background(), nil)
 	if err != nil {
@@ -474,7 +464,7 @@ func TestAudit_AuditRuleMissing(t *testing.T) {
 			"docker ps -q": {out: ""},
 		}),
 		alwaysHasDocker,
-		testdataPath(t, "daemon_default.json"),
+		testutil.TestdataAbsPath(t, "daemon_default.json"),
 		emptyAuditDir(t),
 	)
 	findings, err := m.Audit(context.Background(), nil)
@@ -483,4 +473,3 @@ func TestAudit_AuditRuleMissing(t *testing.T) {
 	}
 	assertStatus(t, findings, "cnt-010", modules.StatusNonCompliant)
 }
-

--- a/internal/modules/logging/module_test.go
+++ b/internal/modules/logging/module_test.go
@@ -16,6 +16,7 @@ package logging_test
 
 import (
 	"context"
+	"github.com/hardbox-io/hardbox/internal/modules/util/testutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -73,10 +74,6 @@ func assertStatus(t *testing.T, findings []modules.Finding, id string, want modu
 		}
 	}
 	t.Errorf("check %s: not found in findings", id)
-}
-
-func testdataPath(elem ...string) string {
-	return filepath.Join(append([]string{"testdata"}, elem...)...)
 }
 
 // noLogrotate returns a path that doesn't exist.
@@ -148,11 +145,11 @@ func TestAudit_AllCompliant(t *testing.T) {
 
 	m := logging.NewModuleForTest(
 		fakeRunner(rsyslogActive()),
-		testdataPath("rsyslog_remote.conf"),
-		testdataPath("nonexistent_dir"), // rsyslog.d not needed (main conf has remote)
-		testdataPath("journald_persistent.conf"),
-		testdataPath("rsyslog_remote.conf"), // reuse as logrotate.conf placeholder
-		testdataPath("nonexistent_dir"),
+		testutil.TestdataPath("rsyslog_remote.conf"),
+		testutil.TestdataPath("nonexistent_dir"), // rsyslog.d not needed (main conf has remote)
+		testutil.TestdataPath("journald_persistent.conf"),
+		testutil.TestdataPath("rsyslog_remote.conf"), // reuse as logrotate.conf placeholder
+		testutil.TestdataPath("nonexistent_dir"),
 		varLog,
 	)
 
@@ -177,11 +174,11 @@ func TestAudit_AllCompliant(t *testing.T) {
 func TestAudit_NoSyslogService_LOG001NonCompliant(t *testing.T) {
 	m := logging.NewModuleForTest(
 		fakeRunner(noSyslogActive()),
-		testdataPath("rsyslog_remote.conf"),
-		testdataPath("nonexistent_dir"),
-		testdataPath("journald_persistent.conf"),
-		testdataPath("rsyslog_remote.conf"),
-		testdataPath("nonexistent_dir"),
+		testutil.TestdataPath("rsyslog_remote.conf"),
+		testutil.TestdataPath("nonexistent_dir"),
+		testutil.TestdataPath("journald_persistent.conf"),
+		testutil.TestdataPath("rsyslog_remote.conf"),
+		testutil.TestdataPath("nonexistent_dir"),
 		t.TempDir(),
 	)
 
@@ -197,11 +194,11 @@ func TestAudit_NoSyslogService_LOG001NonCompliant(t *testing.T) {
 func TestAudit_LocalOnlyRsyslog_LOG002NonCompliant(t *testing.T) {
 	m := logging.NewModuleForTest(
 		fakeRunner(rsyslogActive()),
-		testdataPath("rsyslog_local.conf"),
-		testdataPath("nonexistent_dir"),
-		testdataPath("journald_persistent.conf"),
-		testdataPath("rsyslog_local.conf"),
-		testdataPath("nonexistent_dir"),
+		testutil.TestdataPath("rsyslog_local.conf"),
+		testutil.TestdataPath("nonexistent_dir"),
+		testutil.TestdataPath("journald_persistent.conf"),
+		testutil.TestdataPath("rsyslog_local.conf"),
+		testutil.TestdataPath("nonexistent_dir"),
 		t.TempDir(),
 	)
 
@@ -217,11 +214,11 @@ func TestAudit_LocalOnlyRsyslog_LOG002NonCompliant(t *testing.T) {
 func TestAudit_JournaldDefault_LOG004LOG005NonCompliant(t *testing.T) {
 	m := logging.NewModuleForTest(
 		fakeRunner(rsyslogActive()),
-		testdataPath("rsyslog_remote.conf"),
-		testdataPath("nonexistent_dir"),
-		testdataPath("journald_default.conf"),
-		testdataPath("rsyslog_remote.conf"),
-		testdataPath("nonexistent_dir"),
+		testutil.TestdataPath("rsyslog_remote.conf"),
+		testutil.TestdataPath("nonexistent_dir"),
+		testutil.TestdataPath("journald_default.conf"),
+		testutil.TestdataPath("rsyslog_remote.conf"),
+		testutil.TestdataPath("nonexistent_dir"),
 		t.TempDir(),
 	)
 
@@ -238,11 +235,11 @@ func TestAudit_JournaldDefault_LOG004LOG005NonCompliant(t *testing.T) {
 func TestAudit_NoLogrotate_LOG006NonCompliant(t *testing.T) {
 	m := logging.NewModuleForTest(
 		fakeRunner(rsyslogActive()),
-		testdataPath("rsyslog_remote.conf"),
-		testdataPath("nonexistent_dir"),
-		testdataPath("journald_persistent.conf"),
+		testutil.TestdataPath("rsyslog_remote.conf"),
+		testutil.TestdataPath("nonexistent_dir"),
+		testutil.TestdataPath("journald_persistent.conf"),
 		noLogrotate(),
-		testdataPath("nonexistent_logrotate_dir"),
+		testutil.TestdataPath("nonexistent_logrotate_dir"),
 		t.TempDir(),
 	)
 
@@ -266,11 +263,11 @@ func TestPlan_WritesJournaldKeys(t *testing.T) {
 
 	m := logging.NewModuleForTest(
 		fakeRunner(rsyslogActive()),
-		testdataPath("rsyslog_remote.conf"),
-		testdataPath("nonexistent_dir"),
+		testutil.TestdataPath("rsyslog_remote.conf"),
+		testutil.TestdataPath("nonexistent_dir"),
 		journaldConfPath,
-		testdataPath("rsyslog_remote.conf"),
-		testdataPath("nonexistent_dir"),
+		testutil.TestdataPath("rsyslog_remote.conf"),
+		testutil.TestdataPath("nonexistent_dir"),
 		t.TempDir(),
 	)
 
@@ -315,11 +312,11 @@ func TestPlan_Revert(t *testing.T) {
 
 	m := logging.NewModuleForTest(
 		fakeRunner(rsyslogActive()),
-		testdataPath("rsyslog_remote.conf"),
-		testdataPath("nonexistent_dir"),
+		testutil.TestdataPath("rsyslog_remote.conf"),
+		testutil.TestdataPath("nonexistent_dir"),
 		journaldConfPath,
-		testdataPath("rsyslog_remote.conf"),
-		testdataPath("nonexistent_dir"),
+		testutil.TestdataPath("rsyslog_remote.conf"),
+		testutil.TestdataPath("nonexistent_dir"),
 		t.TempDir(),
 	)
 
@@ -353,11 +350,11 @@ func TestPlan_Revert(t *testing.T) {
 func TestPlan_AlreadyCompliant_NoChanges(t *testing.T) {
 	m := logging.NewModuleForTest(
 		fakeRunner(rsyslogActive()),
-		testdataPath("rsyslog_remote.conf"),
-		testdataPath("nonexistent_dir"),
-		testdataPath("journald_persistent.conf"),
-		testdataPath("rsyslog_remote.conf"),
-		testdataPath("nonexistent_dir"),
+		testutil.TestdataPath("rsyslog_remote.conf"),
+		testutil.TestdataPath("nonexistent_dir"),
+		testutil.TestdataPath("journald_persistent.conf"),
+		testutil.TestdataPath("rsyslog_remote.conf"),
+		testutil.TestdataPath("nonexistent_dir"),
 		t.TempDir(),
 	)
 
@@ -369,4 +366,3 @@ func TestPlan_AlreadyCompliant_NoChanges(t *testing.T) {
 		t.Errorf("expected 0 changes when already compliant, got %d", len(changes))
 	}
 }
-

--- a/internal/modules/util/testutil/testutil.go
+++ b/internal/modules/util/testutil/testutil.go
@@ -1,0 +1,22 @@
+package testutil
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// TestdataPath returns the relative path to a file or directory in testdata/.
+func TestdataPath(elem ...string) string {
+	return filepath.Join(append([]string{"testdata"}, elem...)...)
+}
+
+// TestdataAbsPath returns the absolute path to a file or directory in testdata/, logging an error if it fails.
+// This is provided for compatibility with tests that require absolute paths.
+func TestdataAbsPath(t *testing.T, name string) string {
+	t.Helper()
+	p, err := filepath.Abs(filepath.Join("testdata", name))
+	if err != nil {
+		t.Fatalf("TestdataAbsPath(%q): %v", name, err)
+	}
+	return p
+}


### PR DESCRIPTION
🎯 **What:** Consolidates duplicated `testdataPath` helper functions found in test files (auditd, logging, containers) into a shared `internal/modules/util/testutil` package.
💡 **Why:** Reduces duplicate code, making the codebase easier to maintain. Provides a standard way to get test data paths.
✅ **Verification:** Ran `make test` and all tests passed.
✨ **Result:** Improved maintainability and reduced duplicate logic in test files.

---
*PR created automatically by Jules for task [18202564033375836344](https://jules.google.com/task/18202564033375836344) started by @jackby03*