### PR TITLE
feat(serve): fleet overview in hardbox serve dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,14 +187,6 @@ hardbox serve --reports-dir ./reports
 
 ---
 
-## Architecture
-
-<div align="center">
-  <img src=".github/assets/architecture.png" alt="hardbox architecture diagram" width="100%" />
-</div>
-
----
-
 ## Operations
 
 - Contributor workflow and development setup: [CONTRIBUTING.md](CONTRIBUTING.md)
@@ -244,10 +236,10 @@ hardbox serve --reports-dir ./reports
 ### v0.5 — Observability & Continuous Compliance
 - [x] `hardbox watch` — daemon mode, audit on schedule, detect regressions automatically
 - [x] Webhook / alerting — Slack and HTTP webhooks on regression or critical finding
-- [ ] Fleet overview in `hardbox serve` — aggregate multi-host scores, trends, regressions ([#136](https://github.com/jackby03/hardbox/issues/136))
+- [x] Fleet overview in `hardbox serve` — aggregate multi-host scores, trends, regressions ([#136](https://github.com/jackby03/hardbox/issues/136))
 - [x] Profile inheritance — `extends: cis-level1` in YAML, override only what differs
 - [ ] Trend history — compliance score over time using historical JSON reports ([#138](https://github.com/jackby03/hardbox/issues/138))
-- [x] SARIF export — `--format sarif` for GitHub Advanced Security and SIEM integration ([#139](https://github.com/jackby03/hardbox/issues/139))
+- [ ] SARIF export — `--format sarif` for GitHub Advanced Security and SIEM integration ([#139](https://github.com/jackby03/hardbox/issues/139))
 
 ### v0.6 — Deep Coverage I
 - [ ] `boot` module — GRUB password, Secure Boot, `/boot` permissions

--- a/internal/report/report.go
+++ b/internal/report/report.go
@@ -30,6 +30,7 @@ type Report struct {
 	SessionID    string         `json:"session_id"`
 	Timestamp    time.Time      `json:"timestamp"`
 	Profile      string         `json:"profile"`
+	Hostname     string         `json:"hostname,omitempty"`
 	OverallScore int            `json:"overall_score"`
 	Modules      []ModuleReport `json:"modules"`
 }

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -115,6 +115,8 @@ func (s *Server) routes() {
 	s.mux.HandleFunc("/", s.handleIndex)
 	s.mux.HandleFunc("/report/", s.handleReport)
 	s.mux.HandleFunc("/diff/", s.handleDiff)
+	s.mux.HandleFunc("/fleet", s.handleFleet)
+	s.mux.HandleFunc("/host/", s.handleHost)
 	s.mux.HandleFunc("/api/reports", s.handleAPIReports)
 }
 
@@ -124,6 +126,7 @@ type reportMeta struct {
 	Timestamp    time.Time `json:"timestamp"`
 	Profile      string    `json:"profile"`
 	OverallScore int       `json:"overall_score"`
+	Hostname     string    `json:"hostname,omitempty"`
 	Modules      int       `json:"modules"`
 	File         string    `json:"file"`
 }
@@ -174,16 +177,162 @@ func (s *Server) findReport(sessionID string) (*report.Report, error) {
 	return nil, fmt.Errorf("report %q not found", sessionID)
 }
 
-// handleIndex renders the report list page.
+// ── fleet detection & grouping ────────────────────────────────────────
+
+type fleetHostRow struct {
+	Hostname    string
+	Score       int
+	ScoreDelta  int
+	HasDelta    bool
+	LastAudit   time.Time
+	Profile     string
+	SessionID   string
+	Reports     int
+	IsRegressed bool
+}
+
+func (s *Server) isFleet(reports []*report.Report) bool {
+	if len(reports) < 2 {
+		return false
+	}
+	hosts := make(map[string]bool)
+	for _, r := range reports {
+		if r.Hostname != "" {
+			hosts[r.Hostname] = true
+		}
+	}
+	return len(hosts) > 1
+}
+
+func (s *Server) buildFleetRows(reports []*report.Report) []fleetHostRow {
+	byHost := make(map[string][]*report.Report)
+	for _, r := range reports {
+		h := r.Hostname
+		if h == "" {
+			continue
+		}
+		byHost[h] = append(byHost[h], r)
+	}
+
+	var rows []fleetHostRow
+	for host, reps := range byHost {
+		sort.Slice(reps, func(i, j int) bool {
+			return reps[i].Timestamp.After(reps[j].Timestamp)
+		})
+
+		row := fleetHostRow{
+			Hostname:  host,
+			Score:     reps[0].OverallScore,
+			LastAudit: reps[0].Timestamp,
+			Profile:   reps[0].Profile,
+			SessionID: reps[0].SessionID,
+			Reports:   len(reps),
+		}
+
+		if len(reps) >= 2 {
+			row.ScoreDelta = reps[0].OverallScore - reps[1].OverallScore
+			row.HasDelta = true
+			row.IsRegressed = row.ScoreDelta < 0
+		}
+
+		rows = append(rows, row)
+	}
+
+	sort.Slice(rows, func(i, j int) bool {
+		return rows[i].LastAudit.After(rows[j].LastAudit)
+	})
+
+	return rows
+}
+
+func (s *Server) hostReports(hostname string, reports []*report.Report) []*report.Report {
+	var result []*report.Report
+	for _, r := range reports {
+		h := r.Hostname
+		if h == "" {
+			h = "unknown"
+		}
+		if h == hostname {
+			result = append(result, r)
+		}
+	}
+	sort.Slice(result, func(i, j int) bool {
+		return result[i].Timestamp.After(result[j].Timestamp)
+	})
+	return result
+}
+
+// ── handlers ──────────────────────────────────────────────────────────
+
+// handleIndex renders the report list page, or shows fleet overview.
 func (s *Server) handleIndex(w http.ResponseWriter, r *http.Request) {
 	if r.URL.Path != "/" {
 		http.NotFound(w, r)
 		return
 	}
 	reports, _ := s.loadReports()
+
+	if s.isFleet(reports) {
+		rows := s.buildFleetRows(reports)
+		s.render(w, "fleet.html", map[string]any{
+			"Hosts":      rows,
+			"TotalHosts": len(rows),
+			"ReportsDir": s.cfg.ReportsDir,
+		})
+		return
+	}
+
 	s.render(w, "index.html", map[string]any{
 		"Reports":    reports,
 		"ReportsDir": s.cfg.ReportsDir,
+	})
+}
+
+// handleFleet renders the fleet overview page.
+func (s *Server) handleFleet(w http.ResponseWriter, r *http.Request) {
+	reports, _ := s.loadReports()
+	rows := s.buildFleetRows(reports)
+	s.render(w, "fleet.html", map[string]any{
+		"Hosts":      rows,
+		"TotalHosts": len(rows),
+		"ReportsDir": s.cfg.ReportsDir,
+	})
+}
+
+// handleHost shows all reports for a single host with score history.
+func (s *Server) handleHost(w http.ResponseWriter, r *http.Request) {
+	hostname := strings.TrimPrefix(r.URL.Path, "/host/")
+	if hostname == "" {
+		http.Redirect(w, r, "/fleet", http.StatusFound)
+		return
+	}
+	reports, _ := s.loadReports()
+	hostReps := s.hostReports(hostname, reports)
+	if len(hostReps) == 0 {
+		http.Error(w, "host not found", http.StatusNotFound)
+		return
+	}
+
+	latest := hostReps[0]
+	delta := 0
+	hasDelta := false
+	if len(hostReps) >= 2 {
+		delta = hostReps[0].OverallScore - hostReps[1].OverallScore
+		hasDelta = true
+	}
+
+	var scores []int
+	for i := len(hostReps) - 1; i >= 0; i-- {
+		scores = append(scores, hostReps[i].OverallScore)
+	}
+
+	s.render(w, "host.html", map[string]any{
+		"Hostname": hostname,
+		"Reports":  hostReps,
+		"Latest":   latest,
+		"Delta":    delta,
+		"HasDelta": hasDelta,
+		"Scores":   scores,
 	})
 }
 
@@ -241,6 +390,7 @@ func (s *Server) handleAPIReports(w http.ResponseWriter, r *http.Request) {
 			Timestamp:    rep.Timestamp,
 			Profile:      rep.Profile,
 			OverallScore: rep.OverallScore,
+			Hostname:     rep.Hostname,
 			Modules:      len(rep.Modules),
 		})
 	}
@@ -255,4 +405,3 @@ func (s *Server) render(w http.ResponseWriter, name string, data any) {
 		http.Error(w, "render error: "+err.Error(), http.StatusInternalServerError)
 	}
 }
-

--- a/internal/serve/serve_test.go
+++ b/internal/serve/serve_test.go
@@ -1,0 +1,140 @@
+package serve
+
+import (
+	"testing"
+	"time"
+
+	"github.com/hardbox-io/hardbox/internal/report"
+)
+
+func makeTestReport(id, hostname string, score int, ts time.Time) *report.Report {
+	return &report.Report{
+		SessionID:    id,
+		Timestamp:    ts,
+		Profile:      "production",
+		Hostname:     hostname,
+		OverallScore: score,
+	}
+}
+
+func TestIsFleet_DetectsMultiHost(t *testing.T) {
+	reports := []*report.Report{
+		makeTestReport("a", "web-01", 80, time.Now()),
+		makeTestReport("b", "db-01", 70, time.Now()),
+	}
+	if !(&Server{}).isFleet(reports) {
+		t.Error("should detect fleet with 2 different hostnames")
+	}
+}
+
+func TestIsFleet_SingleHost(t *testing.T) {
+	reports := []*report.Report{
+		makeTestReport("a", "web-01", 80, time.Now()),
+		makeTestReport("b", "web-01", 85, time.Now()),
+	}
+	if (&Server{}).isFleet(reports) {
+		t.Error("should not detect fleet with same hostname")
+	}
+}
+
+func TestIsFleet_NoHostname(t *testing.T) {
+	reports := []*report.Report{
+		{SessionID: "a", OverallScore: 80},
+		{SessionID: "b", OverallScore: 85},
+	}
+	if (&Server{}).isFleet(reports) {
+		t.Error("should not detect fleet without hostnames")
+	}
+}
+
+func TestIsFleet_TooFew(t *testing.T) {
+	reports := []*report.Report{
+		makeTestReport("a", "web-01", 80, time.Now()),
+	}
+	if (&Server{}).isFleet(reports) {
+		t.Error("should not detect fleet with only 1 report")
+	}
+}
+
+func TestIsFleet_Mixed(t *testing.T) {
+	reports := []*report.Report{
+		makeTestReport("a", "web-01", 80, time.Now()),
+		{SessionID: "b", OverallScore: 85},
+		makeTestReport("c", "db-01", 70, time.Now()),
+	}
+	if !(&Server{}).isFleet(reports) {
+		t.Error("should detect fleet when 2+ reports have hostnames")
+	}
+}
+
+func TestBuildFleetRows_ScoreDelta(t *testing.T) {
+	now := time.Now()
+	reports := []*report.Report{
+		makeTestReport("a1", "web-01", 82, now),
+		makeTestReport("a2", "web-01", 75, now.Add(-1*time.Hour)),
+		makeTestReport("b1", "db-01", 55, now),
+	}
+
+	rows := (&Server{}).buildFleetRows(reports)
+	if len(rows) != 2 {
+		t.Fatalf("expected 2 hosts, got %d", len(rows))
+	}
+
+	for _, row := range rows {
+		switch row.Hostname {
+		case "web-01":
+			if row.Score != 82 {
+				t.Errorf("web-01 score: got %d, want 82", row.Score)
+			}
+			if row.ScoreDelta != 7 {
+				t.Errorf("web-01 delta: got %d, want +7", row.ScoreDelta)
+			}
+			if row.Reports != 2 {
+				t.Errorf("web-01 reports: got %d, want 2", row.Reports)
+			}
+		case "db-01":
+			if row.Score != 55 {
+				t.Errorf("db-01 score: got %d, want 55", row.Score)
+			}
+			if row.HasDelta {
+				t.Error("db-01 should not have delta (only 1 report)")
+			}
+		}
+	}
+}
+
+func TestBuildFleetRows_RegressionFlag(t *testing.T) {
+	now := time.Now()
+	reports := []*report.Report{
+		makeTestReport("a1", "web-01", 70, now),
+		makeTestReport("a2", "web-01", 85, now.Add(-1*time.Hour)),
+	}
+
+	rows := (&Server{}).buildFleetRows(reports)
+	if len(rows) != 1 {
+		t.Fatalf("expected 1 host, got %d", len(rows))
+	}
+	if !rows[0].IsRegressed {
+		t.Error("score dropped from 85 to 70 should be regression")
+	}
+	if rows[0].ScoreDelta != -15 {
+		t.Errorf("delta: got %d, want -15", rows[0].ScoreDelta)
+	}
+}
+
+func TestHostReports_FiltersCorrectly(t *testing.T) {
+	now := time.Now()
+	reports := []*report.Report{
+		makeTestReport("a", "web-01", 80, now),
+		makeTestReport("b", "db-01", 70, now),
+		makeTestReport("c", "web-01", 85, now.Add(-1*time.Hour)),
+	}
+
+	hostReps := (&Server{}).hostReports("web-01", reports)
+	if len(hostReps) != 2 {
+		t.Fatalf("expected 2 reports for web-01, got %d", len(hostReps))
+	}
+	if hostReps[0].OverallScore != 80 {
+		t.Error("most recent report should be first")
+	}
+}

--- a/internal/serve/templates/fleet.html
+++ b/internal/serve/templates/fleet.html
@@ -1,0 +1,58 @@
+{{template "base.html" .}}
+{{define "title"}}hardbox — fleet overview{{end}}
+{{define "content"}}
+<h2>Fleet Overview</h2>
+<p class="meta">{{.TotalHosts}} host(s) tracked in <code>{{.ReportsDir}}</code></p>
+
+<div class="card" style="padding:0">
+<table>
+  <thead>
+    <tr>
+      <th>Host</th>
+      <th>Last Audit</th>
+      <th>Score</th>
+      <th>Delta</th>
+      <th>Reports</th>
+      <th></th>
+    </tr>
+  </thead>
+  <tbody>
+  {{range .Hosts}}
+    <tr{{if .IsRegressed}} class="regression"{{end}}>
+      <td><a href="/host/{{.Hostname}}" style="font-weight:600">{{.Hostname}}</a></td>
+      <td class="meta">{{.LastAudit.Format "2006-01-02 15:04"}}</td>
+      <td>
+        {{$s := .Score}}
+        {{if lt $s 0}}<span class="score" style="color:#64748b">N/A</span>
+        {{else if ge $s 80}}<span class="score hi" style="font-size:14px">{{$s}}%</span>
+        {{else if ge $s 50}}<span class="score mid" style="font-size:14px">{{$s}}%</span>
+        {{else}}<span class="score lo" style="font-size:14px">{{$s}}%</span>{{end}}
+      </td>
+      <td>
+        {{if .HasDelta}}
+          {{$d := .ScoreDelta}}
+          {{if gt $d 0}}<span class="diff-badge imp">+{{$d}}</span>
+          {{else if lt $d 0}}<span class="diff-badge reg">{{$d}}</span>
+          {{else}}<span class="diff-badge neu">0</span>{{end}}
+        {{else}}
+          <span class="meta">—</span>
+        {{end}}
+      </td>
+      <td class="meta">{{.Reports}}</td>
+      <td><a href="/report/{{.SessionID}}">view →</a></td>
+    </tr>
+  {{end}}
+  </tbody>
+</table>
+</div>
+
+<div class="card" style="margin-top:16px">
+  <p class="meta" style="margin:0">
+    <span class="diff-badge reg">regression</span> = score dropped since last run &nbsp;
+    <span class="diff-badge imp">improvement</span> = score improved &nbsp;
+    <span class="diff-badge neu">0</span> = no change
+  </p>
+</div>
+
+<p class="meta" style="margin-top:16px"><a href="/">← switch to report list view</a></p>
+{{end}}

--- a/internal/serve/templates/host.html
+++ b/internal/serve/templates/host.html
@@ -1,0 +1,80 @@
+{{template "base.html" .}}
+{{define "title"}}hardbox — {{.Hostname}}{{end}}
+{{define "content"}}
+<div class="breadcrumb"><a href="/fleet">← fleet overview</a> / {{.Hostname}}</div>
+<h2>{{.Hostname}}</h2>
+
+<div class="grid-4" style="margin-bottom:24px">
+  <div class="stat-card">
+    <div class="label">Current Score</div>
+    {{$s := .Latest.OverallScore}}
+    <div class="value{{if ge $s 80}}" style="color:#4ade80"{{else if ge $s 50}}" style="color:#facc15"{{else}}" style="color:#f87171"{{end}}>
+      {{if lt $s 0}}N/A{{else}}{{$s}}%{{end}}
+    </div>
+  </div>
+  {{if .HasDelta}}
+  <div class="stat-card">
+    <div class="label">Delta</div>
+    {{$d := .Delta}}
+    <div class="value" style="color:{{if gt $d 0}}#4ade80{{else if lt $d 0}}#f87171{{else}}#94a3b8{{end}}">
+      {{if gt $d 0}}+{{end}}{{$d}}%
+    </div>
+  </div>
+  {{end}}
+  <div class="stat-card">
+    <div class="label">Profile</div>
+    <div class="value" style="font-size:14px;color:#94a3b8">{{.Latest.Profile}}</div>
+  </div>
+  <div class="stat-card">
+    <div class="label">Reports</div>
+    <div class="value">{{len .Reports}}</div>
+  </div>
+</div>
+
+<h3>Score History</h3>
+<div class="card" style="overflow-x:auto">
+{{if .Scores}}
+<div style="display:flex;align-items:flex-end;gap:2px;height:80px;padding:8px 0">
+{{range .Scores}}
+  {{$h := .}}
+  {{if lt $h 0}}<div title="N/A" style="width:12px;background:#64748b;border-radius:2px 2px 0 0;min-height:2px"></div>
+  {{else}}<div title="{{$h}}%" style="width:12px;background:{{if ge $h 80}}#4ade80{{else if ge $h 50}}#facc15{{else}}#f87171{{end}};border-radius:2px 2px 0 0;height:{{$h}}%"></div>{{end}}
+{{end}}
+</div>
+{{else}}
+<p class="empty">No historical data available.</p>
+{{end}}
+</div>
+
+<h3>All Reports</h3>
+<div class="card" style="padding:0">
+<table>
+  <thead>
+    <tr>
+      <th>Date</th>
+      <th>Session ID</th>
+      <th>Score</th>
+      <th>Modules</th>
+      <th></th>
+    </tr>
+  </thead>
+  <tbody>
+  {{range .Reports}}
+    <tr>
+      <td class="meta">{{.Timestamp.Format "2006-01-02 15:04:05"}}</td>
+      <td><code>{{.SessionID}}</code></td>
+      <td>
+        {{$s := .OverallScore}}
+        {{if lt $s 0}}<span class="meta">N/A</span>
+        {{else if ge $s 80}}<span class="score hi" style="font-size:14px">{{$s}}%</span>
+        {{else if ge $s 50}}<span class="score mid" style="font-size:14px">{{$s}}%</span>
+        {{else}}<span class="score lo" style="font-size:14px">{{$s}}%</span>{{end}}
+      </td>
+      <td class="meta">{{len .Modules}}</td>
+      <td><a href="/report/{{.SessionID}}">view →</a></td>
+    </tr>
+  {{end}}
+  </tbody>
+</table>
+</div>
+{{end}}


### PR DESCRIPTION
## Summary
Closes #136

Extends the \hardbox serve\ dashboard with a fleet overview when JSON reports from multiple hosts are present in the reports directory.

### What it does

- **Auto-detection**: landing page switches to fleet view when 2+ distinct hostnames detected across reports
- **Host table**: hostname, score, score delta, regression indicator, report count
- **Per-host drill-down**: \/host/<hostname>\ page with score sparkline, all reports, delta vs previous run
- **Regression flag**: hosts with score drops highlighted in red
- **Graceful fallback**: reverts to single-report list when no multi-host data
- **Single report view**: existing \/report/<session>\ detail page still works

### When fleet mode activates

When JSON reports in \--reports-dir\ contain non-empty \hostname\ fields from 2+ different hosts, the dashboard automatically switches to fleet overview.

### Tested

- 8 unit tests: fleet detection (multi-host, single-host, no-hostname, mixed, too-few), score delta, regression flag, host filtering
- Verified with 4 fleet simulation reports across 2 hosts