### PR TITLE
feat(serve): compliance score trend history with SVG sparklines

### DIFF
--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"html/template"
+	"math"
 	"net"
 	"net/http"
 	"os"
@@ -51,7 +52,10 @@ type Server struct {
 
 // New creates a Server and parses the embedded templates.
 func New(cfg Config) (*Server, error) {
-	tmpl, err := template.New("").ParseFS(templateFS, "templates/*.html")
+	funcMap := template.FuncMap{
+		"sparklineSVG": sparklineSVG,
+	}
+	tmpl, err := template.New("").Funcs(funcMap).ParseFS(templateFS, "templates/*.html")
 	if err != nil {
 		return nil, fmt.Errorf("parsing templates: %w", err)
 	}
@@ -189,6 +193,59 @@ type fleetHostRow struct {
 	SessionID   string
 	Reports     int
 	IsRegressed bool
+	Trend       trendSummary
+}
+
+// trendSummary carries score history data used to render SVG sparklines.
+type trendSummary struct {
+	Scores []int
+	High   int
+	Low    int
+	Delta  int
+	Count  int
+}
+
+func computeTrend(reports []*report.Report) trendSummary {
+	if len(reports) == 0 {
+		return trendSummary{}
+	}
+	sorted := make([]*report.Report, len(reports))
+	copy(sorted, reports)
+	sort.Slice(sorted, func(i, j int) bool {
+		return sorted[i].Timestamp.Before(sorted[j].Timestamp)
+	})
+	scores := make([]int, len(sorted))
+	high, low := -999, 999
+	for i, r := range sorted {
+		s := r.OverallScore
+		if s < 0 {
+			s = 0
+		}
+		scores[i] = s
+		if s > high {
+			high = s
+		}
+		if s < low {
+			low = s
+		}
+	}
+	if high < 0 {
+		high = 0
+	}
+	if low > 100 {
+		low = 0
+	}
+	delta := 0
+	if len(scores) >= 2 {
+		delta = scores[len(scores)-1] - scores[0]
+	}
+	return trendSummary{
+		Scores: scores,
+		High:   high,
+		Low:    low,
+		Delta:  delta,
+		Count:  len(scores),
+	}
 }
 
 func (s *Server) isFleet(reports []*report.Report) bool {
@@ -227,6 +284,7 @@ func (s *Server) buildFleetRows(reports []*report.Report) []fleetHostRow {
 			Profile:   reps[0].Profile,
 			SessionID: reps[0].SessionID,
 			Reports:   len(reps),
+			Trend:     computeTrend(reps),
 		}
 
 		if len(reps) >= 2 {
@@ -285,6 +343,7 @@ func (s *Server) handleIndex(w http.ResponseWriter, r *http.Request) {
 	s.render(w, "index.html", map[string]any{
 		"Reports":    reports,
 		"ReportsDir": s.cfg.ReportsDir,
+		"Trend":      computeTrend(reports),
 	})
 }
 
@@ -333,6 +392,7 @@ func (s *Server) handleHost(w http.ResponseWriter, r *http.Request) {
 		"Delta":    delta,
 		"HasDelta": hasDelta,
 		"Scores":   scores,
+		"Trend":    computeTrend(hostReps),
 	})
 }
 
@@ -348,7 +408,15 @@ func (s *Server) handleReport(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "report not found", http.StatusNotFound)
 		return
 	}
-	s.render(w, "report.html", map[string]any{"Report": rep})
+	reports, _ := s.loadReports()
+	var hostReps []*report.Report
+	if rep.Hostname != "" {
+		hostReps = s.hostReports(rep.Hostname, reports)
+	}
+	s.render(w, "report.html", map[string]any{
+		"Report": rep,
+		"Trend":  computeTrend(hostReps),
+	})
 }
 
 // handleDiff renders the diff page at /diff/<id1>/<id2>.
@@ -404,4 +472,41 @@ func (s *Server) render(w http.ResponseWriter, name string, data any) {
 	if err := s.tmpl.ExecuteTemplate(w, name, data); err != nil {
 		http.Error(w, "render error: "+err.Error(), http.StatusInternalServerError)
 	}
+}
+
+// sparklineSVG returns an inline SVG sparkline for a trend summary.
+// Width=120, Height=24, only rendered when 2+ data points exist.
+func sparklineSVG(t trendSummary) template.HTML {
+	if t.Count < 2 || len(t.Scores) == 0 {
+		return ""
+	}
+	high, low := t.High, t.Low
+	span := high - low
+	if span == 0 {
+		span = 1
+	}
+
+	w, h := 120.0, 24.0
+	barW := w / float64(len(t.Scores))
+	if barW < 2 {
+		barW = 2
+	}
+
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf(`<svg width="%.0f" height="%.0f" style="vertical-align:middle;margin-left:4px">`, w, h))
+	for i, score := range t.Scores {
+		x := float64(i) * barW
+		barH := math.Max(2, float64(score-low)/float64(span)*h)
+		y := h - barH
+		color := "#4ade80"
+		if score < 50 {
+			color = "#f87171"
+		} else if score < 80 {
+			color = "#facc15"
+		}
+		sb.WriteString(fmt.Sprintf(`<rect x="%.1f" y="%.1f" width="%.1f" height="%.1f" fill="%s" rx="1"/>`,
+			x, y, barW-1, barH, color))
+	}
+	sb.WriteString("</svg>")
+	return template.HTML(sb.String())
 }

--- a/internal/serve/serve_test.go
+++ b/internal/serve/serve_test.go
@@ -1,6 +1,7 @@
 package serve
 
 import (
+	"strings"
 	"testing"
 	"time"
 
@@ -136,5 +137,89 @@ func TestHostReports_FiltersCorrectly(t *testing.T) {
 	}
 	if hostReps[0].OverallScore != 80 {
 		t.Error("most recent report should be first")
+	}
+}
+
+func TestComputeTrend_Basic(t *testing.T) {
+	now := time.Now()
+	reports := []*report.Report{
+		makeTestReport("a", "", 70, now.Add(-2*time.Hour)),
+		makeTestReport("b", "", 75, now.Add(-1*time.Hour)),
+		makeTestReport("c", "", 82, now),
+	}
+	tr := computeTrend(reports)
+	if tr.Count != 3 {
+		t.Errorf("count: got %d, want 3", tr.Count)
+	}
+	if tr.High != 82 {
+		t.Errorf("high: got %d, want 82", tr.High)
+	}
+	if tr.Low != 70 {
+		t.Errorf("low: got %d, want 70", tr.Low)
+	}
+	if tr.Delta != 12 {
+		t.Errorf("delta: got %d, want 12", tr.Delta)
+	}
+	if len(tr.Scores) != 3 {
+		t.Errorf("scores length: got %d, want 3", len(tr.Scores))
+	}
+}
+
+func TestComputeTrend_SingleReport(t *testing.T) {
+	reports := []*report.Report{
+		makeTestReport("a", "", 80, time.Now()),
+	}
+	tr := computeTrend(reports)
+	if tr.Count != 1 {
+		t.Errorf("count: got %d, want 1", tr.Count)
+	}
+	if tr.Delta != 0 {
+		t.Errorf("delta for single report: got %d, want 0", tr.Delta)
+	}
+}
+
+func TestComputeTrend_Empty(t *testing.T) {
+	tr := computeTrend(nil)
+	if tr.Count != 0 {
+		t.Errorf("count for nil: got %d, want 0", tr.Count)
+	}
+}
+
+func TestComputeTrend_NegativeScores(t *testing.T) {
+	now := time.Now()
+	reports := []*report.Report{
+		makeTestReport("a", "", -1, now.Add(-1*time.Hour)),
+		makeTestReport("b", "", 75, now),
+	}
+	tr := computeTrend(reports)
+	if tr.Scores[0] != 0 {
+		t.Errorf("negative score should be 0, got %d", tr.Scores[0])
+	}
+}
+
+func TestSparklineSVG_SinglePoint(t *testing.T) {
+	tr := trendSummary{Scores: []int{80}, Count: 1}
+	svg := sparklineSVG(tr)
+	if svg != "" {
+		t.Error("single point should produce empty SVG")
+	}
+}
+
+func TestSparklineSVG_MultiPoint(t *testing.T) {
+	tr := trendSummary{Scores: []int{50, 60, 70, 80}, Count: 4, High: 80, Low: 50}
+	svg := string(sparklineSVG(tr))
+	if !strings.Contains(svg, "<svg") || !strings.Contains(svg, "</svg>") {
+		t.Error("SVG should have valid tags")
+	}
+	if !strings.Contains(svg, "<rect") {
+		t.Error("SVG should contain rect elements")
+	}
+}
+
+func TestSparklineSVG_Colors(t *testing.T) {
+	tr := trendSummary{Scores: []int{30, 60, 90}, Count: 3, High: 90, Low: 30}
+	svg := string(sparklineSVG(tr))
+	if !strings.Contains(svg, "#4ade80") && !strings.Contains(svg, "#f87171") {
+		t.Error("SVG should have color coding")
 	}
 }

--- a/internal/serve/templates/fleet.html
+++ b/internal/serve/templates/fleet.html
@@ -12,7 +12,7 @@
       <th>Last Audit</th>
       <th>Score</th>
       <th>Delta</th>
-      <th>Reports</th>
+      <th>Trend</th>
       <th></th>
     </tr>
   </thead>
@@ -39,6 +39,7 @@
         {{end}}
       </td>
       <td class="meta">{{.Reports}}</td>
+      <td>{{sparklineSVG .Trend}}</td>
       <td><a href="/report/{{.SessionID}}">view →</a></td>
     </tr>
   {{end}}

--- a/internal/serve/templates/host.html
+++ b/internal/serve/templates/host.html
@@ -32,15 +32,23 @@
 </div>
 
 <h3>Score History</h3>
-<div class="card" style="overflow-x:auto">
-{{if .Scores}}
-<div style="display:flex;align-items:flex-end;gap:2px;height:80px;padding:8px 0">
-{{range .Scores}}
-  {{$h := .}}
-  {{if lt $h 0}}<div title="N/A" style="width:12px;background:#64748b;border-radius:2px 2px 0 0;min-height:2px"></div>
-  {{else}}<div title="{{$h}}%" style="width:12px;background:{{if ge $h 80}}#4ade80{{else if ge $h 50}}#facc15{{else}}#f87171{{end}};border-radius:2px 2px 0 0;height:{{$h}}%"></div>{{end}}
-{{end}}
+<div class="card" style="overflow-x:auto;padding:16px">
+{{if .Trend.Count}}
+{{if gt .Trend.Count 1}}
+<div style="display:flex;gap:24px;align-items:center;margin-bottom:12px">
+  <div style="font-size:12px;color:#94a3b8">
+    {{.Trend.Count}} data points &middot;
+    High: <span style="color:#4ade80;font-weight:600">{{.Trend.High}}%</span>
+    &middot; Low: <span style="color:#f87171;font-weight:600">{{.Trend.Low}}%</span>
+    {{if .Trend.Delta}}
+    &middot; Delta: <span style="color:{{if gt .Trend.Delta 0}}#4ade80{{else}}#f87171{{end}};font-weight:600">{{if gt .Trend.Delta 0}}+{{end}}{{.Trend.Delta}}%</span>
+    {{end}}
+  </div>
+  <div>{{sparklineSVG .Trend}}</div>
 </div>
+{{else}}
+<p class="meta">1 data point — more reports needed for trend analysis.</p>
+{{end}}
 {{else}}
 <p class="empty">No historical data available.</p>
 {{end}}

--- a/internal/serve/templates/index.html
+++ b/internal/serve/templates/index.html
@@ -4,6 +4,25 @@
 <h2>Audit Reports</h2>
 <p class="meta">{{len .Reports}} report(s) in <code>{{.ReportsDir}}</code></p>
 
+{{if .Trend.Count}}
+{{if gt .Trend.Count 1}}
+<div class="card" style="margin-bottom:16px">
+  <div style="display:flex;gap:24px;align-items:center">
+    <div>
+      <div class="label">Score Trend</div>
+      <div style="display:flex;gap:16px;margin-top:4px;font-size:12px">
+        <div>Current: <strong style="color:{{if ge .Trend.High 80}}#4ade80{{else if ge .Trend.High 50}}#facc15{{else}}#f87171{{end}}">{{.Trend.High}}%</strong></div>
+        {{if .Trend.Delta}}<div>Delta: <strong style="color:{{if gt .Trend.Delta 0}}#4ade80{{else}}#f87171{{end}}">{{if gt .Trend.Delta 0}}+{{end}}{{.Trend.Delta}}%</strong></div>{{end}}
+        <div>High: <strong style="color:#4ade80">{{.Trend.High}}%</strong></div>
+        <div>Low: <strong style="color:#f87171">{{.Trend.Low}}%</strong></div>
+      </div>
+    </div>
+    <div>{{sparklineSVG .Trend}}</div>
+  </div>
+</div>
+{{end}}
+{{end}}
+
 {{if not .Reports}}
 <div class="card">
   <p class="empty">No reports found. Run <code>hardbox audit --format json --output report.json</code> to generate one.</p>


### PR DESCRIPTION
## Summary
Closes #138

Adds compliance score trend visualization to \hardbox serve\ dashboard using inline SVG sparklines — no external chart libraries, no database.

### What it does

- **SVG sparklines** in fleet overview table, host detail page, and single-report index
- **Color-coded bars**: green (>=80%), yellow (>=50%), red (<50%)
- **Summary stats**: high score, low score, delta from first report, data point count
- **Derives history from files on disk** — reads all JSON reports, sorts by timestamp
- **Graceful degradation**: shows empty state with 0-1 reports, jumps to trend with 2+

### Where you see it

| View | Sparkline |
|---|---|
| Fleet overview (\/\) | Per-host row in Trend column |
| Host detail (\/host/<name>\) | Above reports table with stats |
| Report index | Trend card above report list |

### Tested
- 15 unit tests covering trend computation, fleet rows, sparkline SVG generation, single/empty/multi-point scenarios