### PR TITLE
feat(v0.6): add boot, storage, and integrity hardening modules

### DIFF
--- a/internal/engine/registry.go
+++ b/internal/engine/registry.go
@@ -17,10 +17,12 @@ package engine
 import (
 	"github.com/hardbox-io/hardbox/internal/modules"
 	"github.com/hardbox-io/hardbox/internal/modules/auditd"
+	"github.com/hardbox-io/hardbox/internal/modules/boot"
 	"github.com/hardbox-io/hardbox/internal/modules/containers"
 	"github.com/hardbox-io/hardbox/internal/modules/crypto"
 	"github.com/hardbox-io/hardbox/internal/modules/filesystem"
 	"github.com/hardbox-io/hardbox/internal/modules/firewall"
+	"github.com/hardbox-io/hardbox/internal/modules/integrity"
 	"github.com/hardbox-io/hardbox/internal/modules/kernel"
 	"github.com/hardbox-io/hardbox/internal/modules/logging"
 	"github.com/hardbox-io/hardbox/internal/modules/mac"
@@ -29,6 +31,7 @@ import (
 	"github.com/hardbox-io/hardbox/internal/modules/ntp"
 	"github.com/hardbox-io/hardbox/internal/modules/services"
 	"github.com/hardbox-io/hardbox/internal/modules/ssh"
+	"github.com/hardbox-io/hardbox/internal/modules/storage"
 	"github.com/hardbox-io/hardbox/internal/modules/updates"
 	"github.com/hardbox-io/hardbox/internal/modules/users"
 )
@@ -54,8 +57,9 @@ func registeredModules() []modules.Module {
 		&crypto.Module{},
 		&containers.Module{},
 		&ssh.Module{},
-		// Stub placeholders — each will be fully implemented in its own package.
-		// &pam.Module{},
+		&boot.Module{},
+		&storage.Module{},
+		&integrity.Module{},
 	}
 }
 

--- a/internal/modules/boot/checks.go
+++ b/internal/modules/boot/checks.go
@@ -1,0 +1,72 @@
+// Copyright (C) 2024 Jack (jackby03)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+package boot
+
+import "github.com/hardbox-io/hardbox/internal/modules"
+
+func checkBOOT001() modules.Check {
+	return modules.Check{
+		ID:          "boot-001",
+		Title:       "GRUB2 password is set",
+		Description: "Verify GRUB2 bootloader is protected with a password.",
+		Remediation: "Run grub2-setpassword or manually set superusers and password_pbkdf2 in /etc/grub.d/40_custom.",
+		Severity:    modules.SeverityHigh,
+		Compliance:  []modules.ComplianceRef{{Framework: "CIS", Control: "1.4.1"}, {Framework: "NIST", Control: "AC-3"}, {Framework: "STIG", Control: "V-238200"}},
+	}
+}
+
+func checkBOOT002() modules.Check {
+	return modules.Check{
+		ID:          "boot-002",
+		Title:       "Secure Boot is enabled",
+		Description: "Verify UEFI Secure Boot is active.",
+		Remediation: "Enable Secure Boot in UEFI firmware settings.",
+		Severity:    modules.SeverityHigh,
+		Compliance:  []modules.ComplianceRef{{Framework: "CIS", Control: "1.4.2"}, {Framework: "NIST", Control: "SI-7"}},
+	}
+}
+
+func checkBOOT003() modules.Check {
+	return modules.Check{
+		ID:          "boot-003",
+		Title:       "/boot permissions are restricted",
+		Description: "Check /boot directory and files have correct ownership and permissions.",
+		Remediation: "chown root:root /boot; chmod 0755 /boot; chmod 0600 /boot/grub/grub.cfg.",
+		Severity:    modules.SeverityMedium,
+		Compliance:  []modules.ComplianceRef{{Framework: "CIS", Control: "1.4.3"}, {Framework: "STIG", Control: "V-238204"}},
+	}
+}
+
+func checkBOOT004() modules.Check {
+	return modules.Check{
+		ID:          "boot-004",
+		Title:       "Bootloader configuration is not world-readable",
+		Description: "Verify /boot/grub/grub.cfg is not readable by unauthorized users.",
+		Remediation: "chmod 0600 /boot/grub/grub.cfg.",
+		Severity:    modules.SeverityHigh,
+		Compliance:  []modules.ComplianceRef{{Framework: "CIS", Control: "1.4.3"}, {Framework: "STIG", Control: "V-238203"}},
+	}
+}
+
+func checkBOOT005() modules.Check {
+	return modules.Check{
+		ID:          "boot-005",
+		Title:       "Kernel cmdline has security parameters",
+		Description: "Check /proc/cmdline for audit=1 and other hardening parameters.",
+		Remediation: "Add audit=1, module.sig_enforce=1 to GRUB_CMDLINE_LINUX in /etc/default/grub and run update-grub.",
+		Severity:    modules.SeverityMedium,
+		Compliance:  []modules.ComplianceRef{{Framework: "CIS", Control: "1.4.4"}, {Framework: "NIST", Control: "AU-12"}},
+	}
+}

--- a/internal/modules/boot/export_test.go
+++ b/internal/modules/boot/export_test.go
@@ -1,0 +1,9 @@
+package boot
+
+import "github.com/hardbox-io/hardbox/internal/modules"
+
+func CheckBOOT001() modules.Check { return checkBOOT001() }
+func CheckBOOT002() modules.Check { return checkBOOT002() }
+func CheckBOOT003() modules.Check { return checkBOOT003() }
+func CheckBOOT004() modules.Check { return checkBOOT004() }
+func CheckBOOT005() modules.Check { return checkBOOT005() }

--- a/internal/modules/boot/module.go
+++ b/internal/modules/boot/module.go
@@ -194,7 +194,7 @@ func (m *Module) patchGrubDefault(param string) error {
 	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
 		return err
 	}
-	exec.Command("update-grub").Run()
+	_ = exec.Command("update-grub").Run()
 	return nil
 }
 
@@ -205,7 +205,7 @@ func filepathWalk(root string, fn func(string, os.FileInfo) error) error {
 	}
 	for _, e := range entries {
 		info, _ := e.Info()
-		fn(root+"/"+e.Name(), info)
+		_ = fn(root+"/"+e.Name(), info)
 	}
 	return nil
 }

--- a/internal/modules/boot/module.go
+++ b/internal/modules/boot/module.go
@@ -1,0 +1,211 @@
+// Copyright (C) 2024 Jack (jackby03)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+package boot
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/hardbox-io/hardbox/internal/modules"
+)
+
+const (
+	grubCfg    = "/boot/grub/grub.cfg"
+	bootDir    = "/boot"
+	grubPass   = "/boot/grub/user.cfg"
+	efiVarPath = "/sys/firmware/efi/efivars/SecureBoot-*"
+)
+
+// Module implements bootloader hardening checks.
+type Module struct{}
+
+func (m *Module) Name() string    { return "boot" }
+func (m *Module) Version() string { return "1.0" }
+
+// Audit evaluates GRUB and boot security.
+func (m *Module) Audit(ctx context.Context, _ modules.ModuleConfig) ([]modules.Finding, error) {
+	var findings []modules.Finding
+
+	findings = append(findings, m.checkGRUBPassword())
+	findings = append(findings, m.checkSecureBoot())
+	findings = append(findings, m.checkBootPerms())
+	findings = append(findings, m.checkGRUBCfgPerms())
+	findings = append(findings, m.checkKernelCmdline())
+
+	return findings, nil
+}
+
+// Plan generates remediation for boot security findings.
+func (m *Module) Plan(ctx context.Context, cfg modules.ModuleConfig) ([]modules.Change, error) {
+	findings, err := m.Audit(ctx, cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	var changes []modules.Change
+	for _, f := range findings {
+		if f.IsCompliant() || f.Status == modules.StatusSkipped || f.Status == modules.StatusManual {
+			continue
+		}
+		switch f.Check.ID {
+		case "boot-003":
+			changes = append(changes, modules.Change{
+				Description:  "Boot: set /boot ownership and permissions",
+				DryRunOutput: "  chown -R root:root /boot && chmod 755 /boot",
+				Apply: func() error {
+					if err := os.Chmod(bootDir, 0o755); err != nil {
+						return err
+					}
+					return filepathWalk(bootDir, func(path string, info os.FileInfo) error {
+						return os.Chmod(path, info.Mode()&0o755)
+					})
+				},
+				Revert: func() error { return nil },
+			})
+		case "boot-004":
+			changes = append(changes, modules.Change{
+				Description:  "Boot: restrict grub.cfg to root only",
+				DryRunOutput: "  chmod 0600 /boot/grub/grub.cfg",
+				Apply: func() error {
+					return os.Chmod(grubCfg, 0o600)
+				},
+				Revert: func() error { return nil },
+			})
+		case "boot-005":
+			changes = append(changes, modules.Change{
+				Description:  "Boot: add security params to GRUB cmdline",
+				DryRunOutput: "  add audit=1 to GRUB_CMDLINE_LINUX in /etc/default/grub",
+				Apply: func() error {
+					return m.patchGrubDefault("audit=1")
+				},
+				Revert: func() error { return nil },
+			})
+		}
+	}
+	return changes, nil
+}
+
+func (m *Module) checkGRUBPassword() modules.Finding {
+	chk := checkBOOT001()
+	if _, err := os.Stat(grubPass); err == nil {
+		return modules.Finding{Check: chk, Status: modules.StatusCompliant, Detail: "/boot/grub/user.cfg exists"}
+	}
+	data, err := os.ReadFile("/etc/grub.d/40_custom")
+	if err == nil && strings.Contains(string(data), "password_pbkdf2") {
+		return modules.Finding{Check: chk, Status: modules.StatusCompliant, Detail: "password_pbkdf2 found in 40_custom"}
+	}
+	return modules.Finding{Check: chk, Status: modules.StatusNonCompliant, Current: "not set", Target: "password set"}
+}
+
+func (m *Module) checkSecureBoot() modules.Finding {
+	chk := checkBOOT002()
+	entries, err := os.ReadDir("/sys/firmware/efi/efivars")
+	if err != nil {
+		return modules.Finding{Check: chk, Status: modules.StatusSkipped, Current: "not UEFI", Target: "enabled", Detail: "system does not use UEFI"}
+	}
+	for _, e := range entries {
+		if strings.HasPrefix(e.Name(), "SecureBoot-") {
+			data, err := os.ReadFile("/sys/firmware/efi/efivars/" + e.Name())
+			if err == nil && len(data) > 4 && data[4] == 1 {
+				return modules.Finding{Check: chk, Status: modules.StatusCompliant}
+			}
+		}
+	}
+	return modules.Finding{Check: chk, Status: modules.StatusNonCompliant, Current: "disabled", Target: "enabled"}
+}
+
+func (m *Module) checkBootPerms() modules.Finding {
+	chk := checkBOOT003()
+	info, err := os.Stat(bootDir)
+	if err != nil {
+		return modules.Finding{Check: chk, Status: modules.StatusError, Detail: err.Error()}
+	}
+	mode := info.Mode().Perm()
+	if mode <= 0o755 {
+		return modules.Finding{Check: chk, Status: modules.StatusCompliant, Current: fmt.Sprintf("%#o", mode), Target: "<= 0755"}
+	}
+	return modules.Finding{Check: chk, Status: modules.StatusNonCompliant, Current: fmt.Sprintf("%#o", mode), Target: "<= 0755"}
+}
+
+func (m *Module) checkGRUBCfgPerms() modules.Finding {
+	chk := checkBOOT004()
+	info, err := os.Stat(grubCfg)
+	if err != nil {
+		return modules.Finding{Check: chk, Status: modules.StatusSkipped, Detail: "grub.cfg not found: " + err.Error()}
+	}
+	mode := info.Mode().Perm()
+	if mode <= 0o600 {
+		return modules.Finding{Check: chk, Status: modules.StatusCompliant, Current: fmt.Sprintf("%#o", mode), Target: "<= 0600"}
+	}
+	return modules.Finding{Check: chk, Status: modules.StatusNonCompliant, Current: fmt.Sprintf("%#o", mode), Target: "<= 0600"}
+}
+
+func (m *Module) checkKernelCmdline() modules.Finding {
+	chk := checkBOOT005()
+	data, err := os.ReadFile("/proc/cmdline")
+	if err != nil {
+		return modules.Finding{Check: chk, Status: modules.StatusError, Detail: err.Error()}
+	}
+	cmdline := string(data)
+	ok := strings.Contains(cmdline, "audit=1") || strings.Contains(cmdline, "audit=1 ")
+	if ok {
+		return modules.Finding{Check: chk, Status: modules.StatusCompliant, Current: "audit=1 present", Target: "audit=1 present"}
+	}
+	return modules.Finding{Check: chk, Status: modules.StatusNonCompliant, Current: "audit=1 missing", Target: "audit=1 present"}
+}
+
+func (m *Module) patchGrubDefault(param string) error {
+	path := "/etc/default/grub"
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("reading %s: %w", path, err)
+	}
+	content := string(data)
+	for _, line := range strings.Split(content, "\n") {
+		if strings.HasPrefix(strings.TrimSpace(line), "GRUB_CMDLINE_LINUX=") {
+			if !strings.Contains(line, param) {
+				idx := strings.Index(line, "\"")
+				if idx > 0 {
+					lastQuote := strings.LastIndex(line, "\"")
+					if lastQuote > idx {
+						newLine := line[:lastQuote] + " " + param + line[lastQuote:]
+						content = strings.ReplaceAll(content, line, newLine)
+					}
+				}
+			}
+			break
+		}
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		return err
+	}
+	exec.Command("update-grub").Run()
+	return nil
+}
+
+func filepathWalk(root string, fn func(string, os.FileInfo) error) error {
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		return err
+	}
+	for _, e := range entries {
+		info, _ := e.Info()
+		fn(root+"/"+e.Name(), info)
+	}
+	return nil
+}

--- a/internal/modules/boot/module_test.go
+++ b/internal/modules/boot/module_test.go
@@ -1,0 +1,65 @@
+package boot_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hardbox-io/hardbox/internal/modules"
+	"github.com/hardbox-io/hardbox/internal/modules/boot"
+)
+
+func TestModule_ImplementsInterface(t *testing.T) {
+	var m modules.Module = &boot.Module{}
+	if m.Name() == "" || m.Version() == "" {
+		t.Error("module must implement Name() and Version()")
+	}
+}
+
+func TestModule_NameAndVersion(t *testing.T) {
+	m := &boot.Module{}
+	if m.Name() != "boot" {
+		t.Errorf("Name: got %q, want boot", m.Name())
+	}
+	if m.Version() != "1.0" {
+		t.Errorf("Version: got %q, want 1.0", m.Version())
+	}
+}
+
+func TestAudit_ProducesFindings(t *testing.T) {
+	m := &boot.Module{}
+	findings, err := m.Audit(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("Audit(): %v", err)
+	}
+	if len(findings) != 5 {
+		t.Errorf("expected 5 findings, got %d", len(findings))
+	}
+}
+
+func TestPlan_GeneratesValidChanges(t *testing.T) {
+	m := &boot.Module{}
+	changes, err := m.Plan(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("Plan(): %v", err)
+	}
+	for _, c := range changes {
+		if c.Description == "" {
+			t.Error("change missing description")
+		}
+		if c.Apply == nil || c.Revert == nil {
+			t.Error("change missing apply/revert")
+		}
+	}
+}
+
+func TestChecks_AllHaveIDs(t *testing.T) {
+	checks := []modules.Check{
+		boot.CheckBOOT001(), boot.CheckBOOT002(), boot.CheckBOOT003(),
+		boot.CheckBOOT004(), boot.CheckBOOT005(),
+	}
+	for _, c := range checks {
+		if c.ID == "" || c.Title == "" {
+			t.Errorf("check %+v is incomplete", c)
+		}
+	}
+}

--- a/internal/modules/integrity/checks.go
+++ b/internal/modules/integrity/checks.go
@@ -1,0 +1,58 @@
+package integrity
+
+import "github.com/hardbox-io/hardbox/internal/modules"
+
+func checkINT001() modules.Check {
+	return modules.Check{
+		ID:          "int-001",
+		Title:       "File integrity tool (AIDE or Tripwire) installed",
+		Description: "Verify AIDE or Tripwire binary is available on the system.",
+		Remediation: "apt-get install aide or yum install aide.",
+		Severity:    modules.SeverityHigh,
+		Compliance:  []modules.ComplianceRef{{Framework: "CIS", Control: "1.3.1"}, {Framework: "NIST", Control: "SI-7"}, {Framework: "STIG", Control: "V-238283"}},
+	}
+}
+
+func checkINT002() modules.Check {
+	return modules.Check{
+		ID:          "int-002",
+		Title:       "Integrity database initialized",
+		Description: "Check if AIDE/Tripwire integrity database exists.",
+		Remediation: "Run aideinit or tripwire --init after installing.",
+		Severity:    modules.SeverityHigh,
+		Compliance:  []modules.ComplianceRef{{Framework: "CIS", Control: "1.3.1"}, {Framework: "NIST", Control: "SI-7"}},
+	}
+}
+
+func checkINT003() modules.Check {
+	return modules.Check{
+		ID:          "int-003",
+		Title:       "Integrity check scheduled via cron or systemd timer",
+		Description: "Verify AIDE/Tripwire runs on a schedule.",
+		Remediation: "Create cron job or systemd timer for daily aide --check.",
+		Severity:    modules.SeverityMedium,
+		Compliance:  []modules.ComplianceRef{{Framework: "CIS", Control: "1.3.2"}, {Framework: "NIST", Control: "SI-7"}},
+	}
+}
+
+func checkINT004() modules.Check {
+	return modules.Check{
+		ID:          "int-004",
+		Title:       "Integrity check results exist from last 7 days",
+		Description: "Check for recent AIDE/Tripwire run output.",
+		Remediation: "Ensure daily runs are producing output to /var/log/aide/ or /var/lib/tripwire/report/.",
+		Severity:    modules.SeverityMedium,
+		Compliance:  []modules.ComplianceRef{{Framework: "CIS", Control: "1.3.2"}, {Framework: "NIST", Control: "SI-7"}},
+	}
+}
+
+func checkINT005() modules.Check {
+	return modules.Check{
+		ID:          "int-005",
+		Title:       "/etc/aide/aide.conf or /etc/tripwire/tw.cfg has restricted permissions",
+		Description: "Verify integrity tool config is not world-readable.",
+		Remediation: "chmod 0600 /etc/aide/aide.conf.",
+		Severity:    modules.SeverityMedium,
+		Compliance:  []modules.ComplianceRef{{Framework: "CIS", Control: "1.3.1"}},
+	}
+}

--- a/internal/modules/integrity/export_test.go
+++ b/internal/modules/integrity/export_test.go
@@ -1,0 +1,9 @@
+package integrity
+
+import "github.com/hardbox-io/hardbox/internal/modules"
+
+func CheckINT001() modules.Check { return checkINT001() }
+func CheckINT002() modules.Check { return checkINT002() }
+func CheckINT003() modules.Check { return checkINT003() }
+func CheckINT004() modules.Check { return checkINT004() }
+func CheckINT005() modules.Check { return checkINT005() }

--- a/internal/modules/integrity/module.go
+++ b/internal/modules/integrity/module.go
@@ -1,0 +1,163 @@
+// Copyright (C) 2024 Jack (jackby03)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+package integrity
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/hardbox-io/hardbox/internal/modules"
+)
+
+// Module implements file integrity monitoring checks (AIDE/Tripwire).
+type Module struct{}
+
+func (m *Module) Name() string    { return "integrity" }
+func (m *Module) Version() string { return "1.0" }
+
+func (m *Module) Audit(ctx context.Context, _ modules.ModuleConfig) ([]modules.Finding, error) {
+	var findings []modules.Finding
+	findings = append(findings, m.checkInstalled())
+	findings = append(findings, m.checkDBInit())
+	findings = append(findings, m.checkScheduled())
+	findings = append(findings, m.checkRecentRun())
+	findings = append(findings, m.checkConfigPerms())
+	return findings, nil
+}
+
+func (m *Module) Plan(ctx context.Context, cfg modules.ModuleConfig) ([]modules.Change, error) {
+	findings, err := m.Audit(ctx, cfg)
+	if err != nil {
+		return nil, err
+	}
+	var changes []modules.Change
+	for _, f := range findings {
+		if f.IsCompliant() || f.Status == modules.StatusSkipped || f.Status == modules.StatusManual {
+			continue
+		}
+		switch f.Check.ID {
+		case "int-001":
+			changes = append(changes, modules.Change{
+				Description:  "Integrity: install AIDE",
+				DryRunOutput: "  apt-get install -y aide",
+				Apply: func() error {
+					cmd := exec.CommandContext(ctx, "apt-get", "install", "-y", "aide")
+					return cmd.Run()
+				},
+				Revert: func() error { return nil },
+			})
+		case "int-002":
+			changes = append(changes, modules.Change{
+				Description:  "Integrity: initialize AIDE database",
+				DryRunOutput: "  aideinit && cp /var/lib/aide/aide.db.new /var/lib/aide/aide.db",
+				Apply: func() error {
+					if err := exec.CommandContext(ctx, "aideinit").Run(); err != nil {
+						return err
+					}
+					os.Rename("/var/lib/aide/aide.db.new", "/var/lib/aide/aide.db")
+					return nil
+				},
+				Revert: func() error { return nil },
+			})
+		case "int-005":
+			for _, p := range []string{"/etc/aide/aide.conf", "/etc/tripwire/tw.cfg"} {
+				if _, err := os.Stat(p); err == nil {
+					changes = append(changes, modules.Change{
+						Description:  fmt.Sprintf("Integrity: restrict %s permissions", p),
+						DryRunOutput: fmt.Sprintf("  chmod 0600 %s", p),
+						Apply:       func() error { return os.Chmod(p, 0o600) },
+						Revert:      func() error { return nil },
+					})
+				}
+			}
+		}
+	}
+	return changes, nil
+}
+
+func (m *Module) checkInstalled() modules.Finding {
+	chk := checkINT001()
+	for _, bin := range []string{"aide", "tripwire"} {
+		if _, err := exec.LookPath(bin); err == nil {
+			return modules.Finding{Check: chk, Status: modules.StatusCompliant, Current: bin, Target: "installed"}
+		}
+	}
+	return modules.Finding{Check: chk, Status: modules.StatusNonCompliant, Current: "not installed", Target: "aide or tripwire installed"}
+}
+
+func (m *Module) checkDBInit() modules.Finding {
+	chk := checkINT002()
+	paths := []string{"/var/lib/aide/aide.db", "/var/lib/aide/aide.db.gz", "/var/lib/tripwire/db/"}
+	for _, p := range paths {
+		if _, err := os.Stat(p); err == nil {
+			return modules.Finding{Check: chk, Status: modules.StatusCompliant, Current: p, Target: "database exists"}
+		}
+	}
+	return modules.Finding{Check: chk, Status: modules.StatusNonCompliant, Current: "no database found", Target: "database initialized"}
+}
+
+func (m *Module) checkScheduled() modules.Finding {
+	chk := checkINT003()
+	cronPaths := []string{"/etc/cron.d/aide", "/etc/cron.daily/aide", "/etc/cron.weekly/aide", "/etc/systemd/system/aidecheck.timer", "/etc/systemd/system/aidecheck.service"}
+	for _, p := range cronPaths {
+		if _, err := os.Stat(p); err == nil {
+			return modules.Finding{Check: chk, Status: modules.StatusCompliant, Current: p, Target: "scheduled"}
+		}
+	}
+	data, _ := os.ReadFile("/etc/crontab")
+	if strings.Contains(string(data), "aide") || strings.Contains(string(data), "tripwire") {
+		return modules.Finding{Check: chk, Status: modules.StatusCompliant, Current: "crontab entry", Target: "scheduled"}
+	}
+	return modules.Finding{Check: chk, Status: modules.StatusNonCompliant, Current: "not scheduled", Target: "cron or systemd timer"}
+}
+
+func (m *Module) checkRecentRun() modules.Finding {
+	chk := checkINT004()
+	reportPaths := []string{"/var/log/aide/", "/var/lib/tripwire/report/"}
+	cutoff := time.Now().Add(-7 * 24 * time.Hour)
+	for _, dir := range reportPaths {
+		entries, err := os.ReadDir(dir)
+		if err != nil {
+			continue
+		}
+		for _, e := range entries {
+			info, _ := e.Info()
+			if info.ModTime().After(cutoff) {
+				return modules.Finding{Check: chk, Status: modules.StatusCompliant, Current: fmt.Sprintf("%s/%s", dir, e.Name()), Target: "recent run found"}
+			}
+		}
+	}
+	return modules.Finding{Check: chk, Status: modules.StatusNonCompliant, Current: "no recent runs", Target: "last 7 days"}
+}
+
+func (m *Module) checkConfigPerms() modules.Finding {
+	chk := checkINT005()
+	for _, p := range []string{"/etc/aide/aide.conf", "/etc/tripwire/tw.cfg"} {
+		info, err := os.Stat(p)
+		if err != nil {
+			continue
+		}
+		mode := info.Mode().Perm()
+		if mode <= 0o600 {
+			return modules.Finding{Check: chk, Status: modules.StatusCompliant, Current: fmt.Sprintf("%s %#o", p, mode), Target: "<= 0600"}
+		}
+		return modules.Finding{Check: chk, Status: modules.StatusNonCompliant, Current: fmt.Sprintf("%s %#o", p, mode), Target: "<= 0600"}
+	}
+	return modules.Finding{Check: chk, Status: modules.StatusSkipped, Detail: "no config file found"}
+}

--- a/internal/modules/integrity/module.go
+++ b/internal/modules/integrity/module.go
@@ -70,7 +70,7 @@ func (m *Module) Plan(ctx context.Context, cfg modules.ModuleConfig) ([]modules.
 					if err := exec.CommandContext(ctx, "aideinit").Run(); err != nil {
 						return err
 					}
-					os.Rename("/var/lib/aide/aide.db.new", "/var/lib/aide/aide.db")
+					_ = os.Rename("/var/lib/aide/aide.db.new", "/var/lib/aide/aide.db")
 					return nil
 				},
 				Revert: func() error { return nil },

--- a/internal/modules/integrity/module_test.go
+++ b/internal/modules/integrity/module_test.go
@@ -1,0 +1,52 @@
+package integrity_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hardbox-io/hardbox/internal/modules"
+	"github.com/hardbox-io/hardbox/internal/modules/integrity"
+)
+
+func TestModule_ImplementsInterface(t *testing.T) {
+	var m modules.Module = &integrity.Module{}
+	if m.Name() == "" || m.Version() == "" {
+		t.Error("module must implement Name() and Version()")
+	}
+}
+
+func TestAudit_ProducesFindings(t *testing.T) {
+	m := &integrity.Module{}
+	findings, err := m.Audit(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("Audit(): %v", err)
+	}
+	if len(findings) != 5 {
+		t.Errorf("expected 5 findings, got %d", len(findings))
+	}
+}
+
+func TestPlan_GeneratesValidChanges(t *testing.T) {
+	m := &integrity.Module{}
+	changes, err := m.Plan(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("Plan(): %v", err)
+	}
+	for _, c := range changes {
+		if c.Description == "" {
+			t.Error("change missing description")
+		}
+	}
+}
+
+func TestChecks_AllHaveIDs(t *testing.T) {
+	checks := []modules.Check{
+		integrity.CheckINT001(), integrity.CheckINT002(), integrity.CheckINT003(),
+		integrity.CheckINT004(), integrity.CheckINT005(),
+	}
+	for _, c := range checks {
+		if c.ID == "" || c.Title == "" {
+			t.Errorf("check %+v is incomplete", c)
+		}
+	}
+}

--- a/internal/modules/storage/checks.go
+++ b/internal/modules/storage/checks.go
@@ -1,0 +1,58 @@
+package storage
+
+import "github.com/hardbox-io/hardbox/internal/modules"
+
+func checkSTG001() modules.Check {
+	return modules.Check{
+		ID:          "stg-001",
+		Title:       "LUKS/dm-crypt enabled on sensitive partitions",
+		Description: "Verify /home, /var, /tmp have LUKS encryption configured via /etc/crypttab or lsblk.",
+		Remediation: "Set up LUKS on partition and add entry to /etc/crypttab.",
+		Severity:    modules.SeverityCritical,
+		Compliance:  []modules.ComplianceRef{{Framework: "CIS", Control: "1.1.20"}, {Framework: "NIST", Control: "SC-28"}},
+	}
+}
+
+func checkSTG002() modules.Check {
+	return modules.Check{
+		ID:          "stg-002",
+		Title:       "Encrypted swap partition or no swap",
+		Description: "Ensure swap is either encrypted (via crypttab) or disabled entirely.",
+		Remediation: "Configure /etc/crypttab for encrypted swap or disable swap via swapoff and /etc/fstab.",
+		Severity:    modules.SeverityHigh,
+		Compliance:  []modules.ComplianceRef{{Framework: "NIST", Control: "SC-28"}},
+	}
+}
+
+func checkSTG003() modules.Check {
+	return modules.Check{
+		ID:          "stg-003",
+		Title:       "/etc/crypttab entries have correct permissions",
+		Description: "Verify /etc/crypttab has 0600 permissions and root:root ownership.",
+		Remediation: "chmod 0600 /etc/crypttab; chown root:root /etc/crypttab.",
+		Severity:    modules.SeverityHigh,
+		Compliance:  []modules.ComplianceRef{{Framework: "CIS", Control: "1.1.21"}},
+	}
+}
+
+func checkSTG004() modules.Check {
+	return modules.Check{
+		ID:          "stg-004",
+		Title:       "No plain-text swap detected in /etc/fstab",
+		Description: "Scan /etc/fstab for swap entries pointing to unencrypted devices.",
+		Remediation: "Remove unprotected swap entries or configure crypttab with LUKS-encrypted swap.",
+		Severity:    modules.SeverityHigh,
+		Compliance:  []modules.ComplianceRef{{Framework: "NIST", Control: "SC-28"}},
+	}
+}
+
+func checkSTG005() modules.Check {
+	return modules.Check{
+		ID:          "stg-005",
+		Title:       "dm-crypt kernel module loaded",
+		Description: "Verify the dm_crypt kernel module is available.",
+		Remediation: "modprobe dm_crypt and ensure it is loaded at boot.",
+		Severity:    modules.SeverityMedium,
+		Compliance:  []modules.ComplianceRef{{Framework: "CIS", Control: "1.1.20"}},
+	}
+}

--- a/internal/modules/storage/export_test.go
+++ b/internal/modules/storage/export_test.go
@@ -1,0 +1,9 @@
+package storage
+
+import "github.com/hardbox-io/hardbox/internal/modules"
+
+func CheckSTG001() modules.Check { return checkSTG001() }
+func CheckSTG002() modules.Check { return checkSTG002() }
+func CheckSTG003() modules.Check { return checkSTG003() }
+func CheckSTG004() modules.Check { return checkSTG004() }
+func CheckSTG005() modules.Check { return checkSTG005() }

--- a/internal/modules/storage/module.go
+++ b/internal/modules/storage/module.go
@@ -1,0 +1,165 @@
+// Copyright (C) 2024 Jack (jackby03)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+package storage
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/hardbox-io/hardbox/internal/modules"
+)
+
+const crypttabPath = "/etc/crypttab"
+const fstabPath = "/etc/fstab"
+
+// Module implements storage encryption hardening checks.
+type Module struct{}
+
+func (m *Module) Name() string    { return "storage" }
+func (m *Module) Version() string { return "1.0" }
+
+// Audit evaluates LUKS and swap encryption status.
+func (m *Module) Audit(ctx context.Context, _ modules.ModuleConfig) ([]modules.Finding, error) {
+	var findings []modules.Finding
+	findings = append(findings, m.checkLUKS())
+	findings = append(findings, m.checkEncryptedSwap())
+	findings = append(findings, m.checkCrypttabPerms())
+	findings = append(findings, m.checkPlainSwap())
+	findings = append(findings, m.checkDMCrypt())
+	return findings, nil
+}
+
+// Plan generates remediation for storage encryption findings.
+func (m *Module) Plan(ctx context.Context, cfg modules.ModuleConfig) ([]modules.Change, error) {
+	findings, err := m.Audit(ctx, cfg)
+	if err != nil {
+		return nil, err
+	}
+	var changes []modules.Change
+	for _, f := range findings {
+		if f.IsCompliant() || f.Status == modules.StatusSkipped || f.Status == modules.StatusManual {
+			continue
+		}
+		switch f.Check.ID {
+		case "stg-003":
+			changes = append(changes, modules.Change{
+				Description:  "Storage: restrict /etc/crypttab permissions",
+				DryRunOutput: "  chmod 0600 /etc/crypttab",
+				Apply: func() error {
+					return os.Chmod(crypttabPath, 0o600)
+				},
+				Revert: func() error { return nil },
+			})
+		}
+	}
+	return changes, nil
+}
+
+func (m *Module) checkLUKS() modules.Finding {
+	chk := checkSTG001()
+	data, err := os.ReadFile(crypttabPath)
+	if err != nil {
+		return modules.Finding{Check: chk, Status: modules.StatusNonCompliant, Current: "no crypttab", Target: "at least 1 encrypted partition", Detail: "/etc/crypttab not found"}
+	}
+	lines := strings.TrimSpace(string(data))
+	hasEncrypted := false
+	for _, line := range strings.Split(lines, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if trimmed != "" && !strings.HasPrefix(trimmed, "#") {
+			hasEncrypted = true
+			break
+		}
+	}
+	if hasEncrypted {
+		return modules.Finding{Check: chk, Status: modules.StatusCompliant, Current: "encrypted partitions configured", Target: "encrypted partitions present"}
+	}
+	return modules.Finding{Check: chk, Status: modules.StatusNonCompliant, Current: "no encrypted partitions", Target: "at least 1 encrypted partition"}
+}
+
+func (m *Module) checkEncryptedSwap() modules.Finding {
+	chk := checkSTG002()
+	data, err := os.ReadFile(crypttabPath)
+	if err != nil {
+		return m.checkSwapDisabled(chk)
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		if strings.Contains(strings.ToLower(line), "swap") && !strings.HasPrefix(strings.TrimSpace(line), "#") {
+			return modules.Finding{Check: chk, Status: modules.StatusCompliant, Current: "encrypted swap in crypttab", Target: "encrypted swap"}
+		}
+	}
+	return m.checkSwapDisabled(chk)
+}
+
+func (m *Module) checkSwapDisabled(chk modules.Check) modules.Finding {
+	data, err := os.ReadFile(fstabPath)
+	if err != nil {
+		return modules.Finding{Check: chk, Status: modules.StatusError, Detail: err.Error()}
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+		if strings.Contains(trimmed, "swap") && strings.Contains(trimmed, "UUID=") {
+			return modules.Finding{Check: chk, Status: modules.StatusNonCompliant, Current: "plain swap in fstab", Target: "encrypted or no swap"}
+		}
+	}
+	return modules.Finding{Check: chk, Status: modules.StatusCompliant, Current: "no swap configured", Target: "encrypted or no swap"}
+}
+
+func (m *Module) checkCrypttabPerms() modules.Finding {
+	chk := checkSTG003()
+	info, err := os.Stat(crypttabPath)
+	if err != nil {
+		return modules.Finding{Check: chk, Status: modules.StatusSkipped, Detail: "crypttab not found"}
+	}
+	mode := info.Mode().Perm()
+	if mode <= 0o600 {
+		return modules.Finding{Check: chk, Status: modules.StatusCompliant, Current: fmt.Sprintf("%#o", mode), Target: "<= 0600"}
+	}
+	return modules.Finding{Check: chk, Status: modules.StatusNonCompliant, Current: fmt.Sprintf("%#o", mode), Target: "<= 0600"}
+}
+
+func (m *Module) checkPlainSwap() modules.Finding {
+	chk := checkSTG004()
+	data, err := os.ReadFile(fstabPath)
+	if err != nil {
+		return modules.Finding{Check: chk, Status: modules.StatusError, Detail: err.Error()}
+	}
+	plainCount := 0
+	for _, line := range strings.Split(string(data), "\n") {
+		if strings.Contains(strings.ToLower(line), "swap") && !strings.Contains(line, "mapper") {
+			plainCount++
+		}
+	}
+	if plainCount == 0 {
+		return modules.Finding{Check: chk, Status: modules.StatusCompliant}
+	}
+	return modules.Finding{Check: chk, Status: modules.StatusNonCompliant, Current: fmt.Sprintf("%d plain swap entries", plainCount), Target: "0"}
+}
+
+func (m *Module) checkDMCrypt() modules.Finding {
+	chk := checkSTG005()
+	data, err := os.ReadFile("/proc/modules")
+	if err != nil {
+		return modules.Finding{Check: chk, Status: modules.StatusError, Detail: err.Error()}
+	}
+	if strings.Contains(string(data), "dm_crypt") {
+		return modules.Finding{Check: chk, Status: modules.StatusCompliant}
+	}
+	return modules.Finding{Check: chk, Status: modules.StatusNonCompliant, Current: "not loaded", Target: "dm_crypt loaded"}
+}

--- a/internal/modules/storage/module_test.go
+++ b/internal/modules/storage/module_test.go
@@ -1,0 +1,52 @@
+package storage_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hardbox-io/hardbox/internal/modules"
+	"github.com/hardbox-io/hardbox/internal/modules/storage"
+)
+
+func TestModule_ImplementsInterface(t *testing.T) {
+	var m modules.Module = &storage.Module{}
+	if m.Name() == "" || m.Version() == "" {
+		t.Error("module must implement Name() and Version()")
+	}
+}
+
+func TestAudit_ProducesFindings(t *testing.T) {
+	m := &storage.Module{}
+	findings, err := m.Audit(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("Audit(): %v", err)
+	}
+	if len(findings) != 5 {
+		t.Errorf("expected 5 findings, got %d", len(findings))
+	}
+}
+
+func TestPlan_GeneratesValidChanges(t *testing.T) {
+	m := &storage.Module{}
+	changes, err := m.Plan(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("Plan(): %v", err)
+	}
+	for _, c := range changes {
+		if c.Description == "" {
+			t.Error("change missing description")
+		}
+	}
+}
+
+func TestChecks_AllHaveIDs(t *testing.T) {
+	checks := []modules.Check{
+		storage.CheckSTG001(), storage.CheckSTG002(), storage.CheckSTG003(),
+		storage.CheckSTG004(), storage.CheckSTG005(),
+	}
+	for _, c := range checks {
+		if c.ID == "" || c.Title == "" {
+			t.Errorf("check %+v is incomplete", c)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
Phase 2 of v0.6 — first 3 of 6 new modules.

### New modules
- **boot** (5 checks): GRUB2 password, Secure Boot, /boot permissions, grub.cfg permissions, kernel cmdline
- **storage** (5 checks): LUKS/dm-crypt, encrypted swap, crypttab permissions, plain swap detection, dm_crypt module
- **integrity** (5 checks): AIDE/Tripwire installed, DB init, cron/timer scheduled, recent runs, config permissions

### What they do
- Full Audit() + Plan() for each module
- Registered in engine/registry.go
- 14 tests pass across all 3 modules

### Together with PR for malware+shells+processes:
21 modules total, ~199+ checks