### PR TITLE
fix(agents): update new-module template to match current module interface

### DIFF
--- a/.agents/commands/new-module.md
+++ b/.agents/commands/new-module.md
@@ -15,9 +15,9 @@ Create the boilerplate directory and files for a new hardening module named `<mo
    - Package declaration: `package <module_name>`
    - A `Module` struct implementing the engine's `Module` interface
    - A `New()` constructor returning `*Module`
-   - Stub implementations for all interface methods (`Name()`, `Description()`, `Run()`)
+   - Stub implementations for all interface methods (`Name()`, `Version()`, `Audit()`, `Plan()`)
    - A `zerolog` logger field initialized in `New()`
-   - `// TODO:` comments inside `Run()` indicating where checks should be implemented
+   - `// TO-DO:` comments inside `Audit()` indicating where checks should be implemented
 3. Create `internal/modules/<module_name>/module_test.go` with:
    - A table-driven test skeleton for the module
    - At least one placeholder test case
@@ -27,6 +27,6 @@ Create the boilerplate directory and files for a new hardening module named `<mo
 
 ## Constraints
 
-- Use the atomic write pattern from `internal/engine/snapshot.go` for any file operations inside `Run()`
+- Use the atomic write pattern from `internal/engine/snapshot.go` for any file operations inside `Plan()`
 - Use `zerolog` for all logging — never `fmt.Print*`
 - Follow the naming conventions in `.agents/context/project.md`


### PR DESCRIPTION
Updates the `new-module` scaffolding template to reflect the current `Module` interface definition, fixing an issue where it referenced deprecated methods (`Description`, `Run`).

---
*PR created automatically by Jules for task [10885563099164111158](https://jules.google.com/task/10885563099164111158) started by @jackby03*