### PR TITLE
test(distro): add missing-file error test for parseKeyValueFile

### DIFF
--- a/internal/distro/distro.go
+++ b/internal/distro/distro.go
@@ -181,4 +181,3 @@ func resolveFamily(id, idLike string) Family {
 	}
 	return FamilyUnknown
 }
-

--- a/internal/distro/distro_test.go
+++ b/internal/distro/distro_test.go
@@ -128,3 +128,9 @@ func assertEqual(t *testing.T, field, want, got string) {
 	}
 }
 
+func TestParseKeyValueFile_NonExistentFile(t *testing.T) {
+	_, err := distro.TestParseKeyValueFile("testdata/does_not_exist_file")
+	if err == nil {
+		t.Fatal("expected error for non-existent file, got nil")
+	}
+}

--- a/internal/distro/export_test.go
+++ b/internal/distro/export_test.go
@@ -18,3 +18,4 @@ package distro
 // tests outside this package. It is only compiled during testing.
 var TestDetectFromPaths = detectFromPaths
 
+var TestParseKeyValueFile = parseKeyValueFile


### PR DESCRIPTION
🎯 **What:** Added a missing test case for `parseKeyValueFile` to check missing-file error behavior.
📊 **Coverage:** Specifically tested the condition where a given path does not exist, ensuring `parseKeyValueFile` correctly returns a non-nil error.
✨ **Result:** Improved robustness by confirming error handling functionality when a file is absent, and keeping test assertions simple.

---
*PR created automatically by Jules for task [5222939411389773538](https://jules.google.com/task/5222939411389773538) started by @jackby03*