### PR TITLE
test: add permission denied test for readStringIfExists

### DIFF
--- a/internal/modules/crypto/export_test.go
+++ b/internal/modules/crypto/export_test.go
@@ -37,6 +37,7 @@ var (
 	ParseOpenSSLMinProtocol   = parseOpenSSLMinProtocol
 	ParseOpenSSLCipherString  = parseOpenSSLCipherString
 	GPGUsesLongKeyID          = gpgUsesLongKeyID
+	ReadStringIfExists        = readStringIfExists
 )
 
 func FakeDistroDebian() (*distro.Info, error) {
@@ -46,4 +47,3 @@ func FakeDistroDebian() (*distro.Info, error) {
 func FakeDistroRHEL() (*distro.Info, error) {
 	return &distro.Info{ID: "rhel", Family: distro.FamilyRHEL}, nil
 }
-

--- a/internal/modules/crypto/module_test.go
+++ b/internal/modules/crypto/module_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/hardbox-io/hardbox/internal/modules"
@@ -155,6 +156,9 @@ func TestHelpers(t *testing.T) {
 }
 
 func TestReadStringIfExists_PermissionDenied(t *testing.T) {
+	if runtime.GOOS != "windows" && os.Geteuid() == 0 {
+		t.Skip("Skipping test on root as root can read files with 000 permissions")
+	}
 	dir := t.TempDir()
 	path := filepath.Join(dir, "noperm")
 	if err := os.WriteFile(path, []byte("test"), 0000); err != nil {

--- a/internal/modules/crypto/module_test.go
+++ b/internal/modules/crypto/module_test.go
@@ -16,6 +16,7 @@ package crypto_test
 
 import (
 	"context"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -153,6 +154,19 @@ func TestHelpers(t *testing.T) {
 	}
 }
 
+func TestReadStringIfExists_PermissionDenied(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "noperm")
+	if err := os.WriteFile(path, []byte("test"), 0000); err != nil {
+		t.Fatalf("failed to write test file: %v", err)
+	}
+
+	_, err := crypto.ReadStringIfExists(path)
+	if err == nil {
+		t.Fatal("expected an error due to permission denied, but got nil")
+	}
+}
+
 func td(name string) string {
 	return filepath.Join("testdata", name)
 }
@@ -169,4 +183,3 @@ func assertStatus(t *testing.T, findings []modules.Finding, id string, want modu
 	}
 	t.Fatalf("check %s not found", id)
 }
-


### PR DESCRIPTION
🎯 **What:** The testing gap addressed: Missing error test for `readStringIfExists` permission denied.
📊 **Coverage:** Covered the scenario where a file exists but lacks read permissions, verifying that the function propagates the error instead of returning an empty string.
✨ **Result:** Improved test coverage and ensured correct error handling is maintained during refactoring.

---
*PR created automatically by Jules for task [4619167829954316001](https://jules.google.com/task/4619167829954316001) started by @jackby03*